### PR TITLE
Fix mobile menu and logo navigation

### DIFF
--- a/your-documents-pl.html
+++ b/your-documents-pl.html
@@ -6,6 +6,7 @@
     <title>Your Documents – Idol Brands</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="auth.js"></script>
     <script src="cms-sync.js"></script>
     <script src="documents-sync.js"></script>
@@ -16,7 +17,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between items-center h-16">
                 <div class="flex items-center flex-shrink-0">
-                    <h1 class="text-xl sm:text-2xl font-display font-bold text-black">Idol Brands</h1>
+                    <a href="index-pl.html" class="text-xl sm:text-2xl font-display font-bold text-black">Idol Brands</a>
                 </div>
                 <div class="hidden lg:flex items-center space-x-4 xl:space-x-8 flex-wrap">
                     <a href="about-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">O&nbsp;nas</a>

--- a/your-documents.html
+++ b/your-documents.html
@@ -6,6 +6,7 @@
     <title>Your Documents – Idol Brands</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <script src="auth.js"></script>
     <script src="cms-sync.js"></script>
     <script src="documents-sync.js"></script>
@@ -16,7 +17,7 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between items-center h-16">
                 <div class="flex items-center flex-shrink-0">
-                    <h1 class="text-xl sm:text-2xl font-display font-bold text-black">Idol Brands</h1>
+                    <a href="index.html" class="text-xl sm:text-2xl font-display font-bold text-black">Idol Brands</a>
                 </div>
                 <div class="hidden lg:flex items-center space-x-4 xl:space-x-8 flex-wrap">
                     <a href="about.html" class="text-black hover:text-gray-600 transition-colors font-medium">About</a>


### PR DESCRIPTION
Add Font Awesome CSS and make the logo clickable in "Your Documents" pages to restore mobile navigation.

The hamburger menu icon was not visible due to a missing Font Awesome library, and the logo was not a clickable link, preventing users from returning to the homepage on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-7dabfb66-dbb6-4b42-bdfe-f11111758661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7dabfb66-dbb6-4b42-bdfe-f11111758661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

