### PR TITLE
Fix impact statistics label display

### DIFF
--- a/IMPACT_STATS_ARCHITECTURE.md
+++ b/IMPACT_STATS_ARCHITECTURE.md
@@ -1,0 +1,201 @@
+# 🏗️ Impact Statistics - Architektura Systemu
+
+## 📊 Przepływ Danych
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    ADMIN PANEL (admin.html)                  │
+│                                                              │
+│  Section: "Edit About Page"                                 │
+│  Subsection: "Our Impact Statistics (EN & PL)"              │
+│                                                              │
+│  ┌────────────────────────────────────────────────────┐     │
+│  │ Statistic 1                                        │     │
+│  │ ┌──────────┐ ┌──────────────┐ ┌─────────────────┐│     │
+│  │ │Value     │ │Label (EN)    │ │Label (PL)       ││     │
+│  │ │(Shared)  │ │              │ │                 ││     │
+│  │ │[500+   ] │ │[Brands...  ] │ │[Marek Uru...]  ││     │
+│  │ └──────────┘ └──────────────┘ └─────────────────┘│     │
+│  └────────────────────────────────────────────────────┘     │
+│                                                              │
+│  [Save About Content] ← Jeden przycisk dla wszystkiego      │
+└──────────────────────────────────────────────────────────────┘
+                            │
+                            │ Zapisuje do localStorage:
+                            ├─→ impactStat1Value
+                            ├─→ impactStat1Label (EN)
+                            └─→ plImpactStat1Label (PL)
+                            │
+        ┌───────────────────┴───────────────────┐
+        │                                       │
+        ▼                                       ▼
+┌────────────────────┐                 ┌────────────────────┐
+│   STRONY EN        │                 │   STRONY PL        │
+├────────────────────┤                 ├────────────────────┤
+│ about.html         │                 │ about-pl.html      │
+│ success-stories    │                 │ success-stories-pl │
+│        .html       │                 │         .html      │
+├────────────────────┤                 ├────────────────────┤
+│ Ładują:            │                 │ Ładują:            │
+│ • impactStat1Value │                 │ • impactStat1Value │
+│ • impactStat1Label │                 │ • plImpactStat1Label│
+└────────────────────┘                 └────────────────────┘
+        │                                       │
+        │                                       │
+        ▼                                       ▼
+┌────────────────────┐                 ┌────────────────────┐
+│ Wyświetla:         │                 │ Wyświetla:         │
+│ 500+               │                 │ 500+               │
+│ Brands Launched    │                 │ Uruchomionych Marek│
+└────────────────────┘                 └────────────────────┘
+```
+
+## 🗂️ Struktura localStorage
+
+```javascript
+// WARTOŚCI (współdzielone EN & PL)
+localStorage: {
+  impactStat1Value: "500+",
+  impactStat2Value: "$50M",
+  impactStat3Value: "2.4M",
+  impactStat4Value: "98%",
+  
+  // ETYKIETY EN
+  impactStat1Label: "Fashion Brands Launched",
+  impactStat2Label: "In Brand Sales",
+  impactStat3Label: "Products Sold",
+  impactStat4Label: "Success Rate",
+  
+  // ETYKIETY PL
+  plImpactStat1Label: "Uruchomionych Marek Modowych",
+  plImpactStat2Label: "Sprzedaż Marek",
+  plImpactStat3Label: "Sprzedanych Produktów",
+  plImpactStat4Label: "Wskaźnik Sukcesu"
+}
+```
+
+## 📄 Mapowanie Stron → Elementy DOM
+
+### about.html (EN)
+```javascript
+document.getElementById('impact-stat1-value').textContent 
+  = localStorage.getItem('impactStat1Value');
+  
+document.getElementById('impact-stat1-label').textContent 
+  = localStorage.getItem('impactStat1Label');
+```
+
+### about-pl.html (PL)
+```javascript
+document.getElementById('impact-stat1-value').textContent 
+  = localStorage.getItem('impactStat1Value');  // Ta sama wartość!
+  
+document.getElementById('impact-stat1-label').textContent 
+  = localStorage.getItem('plImpactStat1Label');  // Polska etykieta!
+```
+
+### success-stories.html (EN)
+```javascript
+document.getElementById('success-stat1-value').textContent 
+  = localStorage.getItem('impactStat1Value');  // Te same dane!
+  
+document.getElementById('success-stat1-label').textContent 
+  = localStorage.getItem('impactStat1Label');
+```
+
+### success-stories-pl.html (PL)
+```javascript
+document.getElementById('success-stat1-value').textContent 
+  = localStorage.getItem('impactStat1Value');  // Te same dane!
+  
+document.getElementById('success-stat1-label').textContent 
+  = localStorage.getItem('plImpactStat1Label');  // Polska etykieta!
+```
+
+## 🔄 Cykl Życia Danych
+
+```
+1. Admin otwiera admin.html
+   │
+   ├─→ JavaScript ładuje wartości z localStorage
+   │   do pól formularza
+   │
+2. Admin edytuje pola:
+   │  • Value (Shared): "500+" → "1000+"
+   │  • Label (EN): "Fashion Brands Launched"
+   │  • Label (PL): "Uruchomionych Marek Modowych"
+   │
+3. Admin klika "Save About Content"
+   │
+   ├─→ JavaScript zapisuje do localStorage:
+   │   • impactStat1Value = "1000+"
+   │   • impactStat1Label = "Fashion Brands Launched"
+   │   • plImpactStat1Label = "Uruchomionych Marek Modowych"
+   │
+4. Użytkownik odświeża strony:
+   │
+   ├─→ about.html:
+   │   └─→ Wyświetla: "1000+" + "Fashion Brands Launched"
+   │
+   ├─→ about-pl.html:
+   │   └─→ Wyświetla: "1000+" + "Uruchomionych Marek Modowych"
+   │
+   ├─→ success-stories.html:
+   │   └─→ Wyświetla: "1000+" + "Fashion Brands Launched"
+   │
+   └─→ success-stories-pl.html:
+       └─→ Wyświetla: "1000+" + "Uruchomionych Marek Modowych"
+```
+
+## 🎯 Kluczowe Zalety Architektury
+
+1. **Single Source of Truth** 
+   - Jedna sekcja w admin.html zarządza wszystkimi statystykami
+
+2. **DRY (Don't Repeat Yourself)**
+   - Wartości współdzielone między EN i PL
+   - Zmiana raz = aktualizacja 4 stron
+
+3. **Separation of Concerns**
+   - Wartości oddzielone od etykiet
+   - Etykiety oddzielone per język
+
+4. **User-Friendly**
+   - Wszystkie pola obok siebie
+   - Jeden przycisk zapisuje wszystko
+   - Wizualne oddzielenie statystyk
+
+5. **Maintainable**
+   - Jasna struktura kodu
+   - Łatwe debugowanie
+   - Łatwe rozszerzanie (dodanie kolejnych języków)
+
+## 🔧 Pliki Zaangażowane
+
+| Plik | Rola |
+|------|------|
+| `admin.html` | UI + JavaScript do zarządzania statystykami |
+| `admin-pl.js` | Inicjalizacja domyślnych wartości PL |
+| `about.html` | Wyświetla statystyki EN |
+| `about-pl.html` | Wyświetla statystyki PL |
+| `success-stories.html` | Wyświetla statystyki EN |
+| `success-stories-pl.html` | Wyświetla statystyki PL |
+
+## 📝 Zasady Kodowania
+
+1. **Nazewnictwo:**
+   - EN: `impactStat{N}Label`
+   - PL: `plImpactStat{N}Label`
+   - Wartości: `impactStat{N}Value` (bez prefiksu języka)
+
+2. **Fallback:**
+   - Zawsze używaj `||` operator dla domyślnych wartości
+   - PL może fallbackować na EN jeśli brak tłumaczenia
+
+3. **Konsystencja:**
+   - Ta sama kolejność pól w formularzu
+   - Ta sama struktura dla każdej statystyki
+
+## 🎉 Rezultat
+
+System jest teraz **spójny, intuicyjny i łatwy w utrzymaniu**! 

--- a/IMPACT_STATS_FIX_SUMMARY.md
+++ b/IMPACT_STATS_FIX_SUMMARY.md
@@ -1,0 +1,96 @@
+# ✅ Naprawa Impact Statistics CMS - Oddzielne Etykiety dla EN i PL
+
+## 🎯 Problem
+
+Poprzednia implementacja Impact Statistics CMS miała etykiety dla wersji polskiej ukryte w oddzielnej sekcji daleko w dół panelu admina (w sekcji "Strona 'O nas' (PL)"). Użytkownicy mogli nie zauważyć, że etykiety dla PL są edytowane w innym miejscu niż EN, co prowadziło do zamieszania.
+
+## ✅ Rozwiązanie
+
+Połączono zarządzanie etykietami EN i PL w **jednej sekcji** "Our Impact Statistics (EN & PL)" w "Edit About Page".
+
+### Co zostało zmienione:
+
+#### 1. **admin.html**
+- ✅ Każda statystyka ma teraz **3 pola obok siebie**:
+  - **Value (Shared)** - wartość współdzielona dla EN i PL
+  - **Label (EN)** - etykieta po angielsku
+  - **Label (PL)** - etykieta po polsku
+- ✅ Dodano wizualne oddzielenie - każda statystyka w osobnym bloku z szarym tłem
+- ✅ Tytuł zmieniony na "Our Impact Statistics (EN & PL)"
+- ✅ JavaScript zapisuje zarówno EN jak i PL etykiety jednym przyciskiem "Save About Content"
+
+#### 2. **admin-pl.js**
+- ✅ Usunięto ładowanie i zapisywanie pól `plImpactStat*Label` (teraz zarządzane przez admin.html)
+- ✅ Zachowano inicjalizację domyślnych wartości PL
+
+#### 3. **Sekcja PL "Strona 'O nas' (PL)"**
+- ✅ Usunięto duplikujące pola dla etykiet PL
+- ✅ Dodano informację gdzie zarządzać statystykami
+
+## 🎨 Nowy Layout
+
+Każda statystyka wygląda teraz tak:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Statistic 1                                             │
+├─────────────────────────────────────────────────────────┤
+│ [Value (Shared)] [Label (EN)]      [Label (PL)]        │
+│ [500+          ] [Brands Launched] [Marek Uruchomionych]│
+└─────────────────────────────────────────────────────────┘
+```
+
+## 📍 Jak używać
+
+1. Wejdź na `/admin.html`
+2. Przewiń do sekcji **"Edit About Page"**
+3. Znajdź **"Our Impact Statistics (EN & PL)"**
+4. Dla każdej statystyki edytuj:
+   - **Value (Shared)** - ta sama wartość dla EN i PL (np. "500+")
+   - **Label (EN)** - etykieta po angielsku (np. "Fashion Brands Launched")
+   - **Label (PL)** - etykieta po polsku (np. "Uruchomionych Marek Modowych")
+5. Kliknij **"Save About Content"**
+6. Gotowe! ✅
+
+## ✨ Korzyści
+
+- ✅ **Wszystko w jednym miejscu** - nie trzeba szukać w różnych sekcjach
+- ✅ **Przejrzysty layout** - EN i PL obok siebie
+- ✅ **Jeden przycisk** - zapisz EN i PL jednocześnie
+- ✅ **Wizualne oddzielenie** - łatwo rozpoznać każdą statystykę
+- ✅ **Automatyczna synchronizacja** - zmiana aktualizuje 4 strony:
+  - `/about.html` (EN)
+  - `/about-pl.html` (PL)
+  - `/success-stories.html` (EN)
+  - `/success-stories-pl.html` (PL)
+
+## 🔧 Techniczne szczegóły
+
+### Zmienione localStorage keys:
+
+**Wartości (współdzielone):**
+- `impactStat1Value`, `impactStat2Value`, `impactStat3Value`, `impactStat4Value`
+
+**Etykiety EN:**
+- `impactStat1Label`, `impactStat2Label`, `impactStat3Label`, `impactStat4Label`
+
+**Etykiety PL:**
+- `plImpactStat1Label`, `plImpactStat2Label`, `plImpactStat3Label`, `plImpactStat4Label`
+
+### Jak strony ładują dane:
+
+**about.html & success-stories.html:**
+```javascript
+const value = localStorage.getItem('impactStat1Value');
+const label = localStorage.getItem('impactStat1Label');
+```
+
+**about-pl.html & success-stories-pl.html:**
+```javascript
+const value = localStorage.getItem('impactStat1Value'); // ta sama wartość!
+const label = localStorage.getItem('plImpactStat1Label'); // polska etykieta!
+```
+
+## 🎉 Rezultat
+
+Teraz CMS dla Impact Statistics jest **intuicyjny, przejrzysty i łatwy w użyciu**! Wszystkie etykiety dla obu języków są w jednym miejscu, co eliminuje zamieszanie i przyspiesza edycję treści.

--- a/ZINTEGROWANE_OUR_IMPACT.md
+++ b/ZINTEGROWANE_OUR_IMPACT.md
@@ -14,30 +14,22 @@
 
 **Wejdź na panel admin**: `/admin.html` (login: admin / idoladmin2025)
 
-#### Dla wersji angielskiej (EN):
+#### Dla WSZYSTKICH wersji (EN i PL):
 ```
 Sekcja: "Edit About Page"
   ↓
-Podsekcja: "Our Impact Statistics (EN)"
+Podsekcja: "Our Impact Statistics (EN & PL)"
   ↓
-Edytuj 4 pola (Value + Label)
+Dla każdej statystyki edytuj 3 pola:
+  • Value (Shared) - wartość współdzielona dla EN i PL
+  • Label (EN) - etykieta po angielsku
+  • Label (PL) - etykieta po polsku
   ↓
 Klik: "Save About Content"
   ↓
-✅ Zmieni się ZARÓWNO na About JAK I Success Stories!
-```
-
-#### Dla wersji polskiej (PL):
-```
-Sekcja: "Strona 'O nas' (PL)"
-  ↓
-Podsekcja: "Statystyki 'Nasz Wpływ' (PL)"
-  ↓
-Edytuj 4 pola (Wartość + Etykieta)
-  ↓
-Klik: "Zapisz treści 'O nas' (PL)"
-  ↓
-✅ Zmieni się ZARÓWNO na O nas JAK I Historie sukcesu!
+✅ Zmieni się ZARÓWNO na About/O nas JAK I Success Stories/Historie sukcesu!
+✅ W wersji EN wyświetli się Label (EN)
+✅ W wersji PL wyświetli się Label (PL)
 ```
 
 ---
@@ -65,18 +57,23 @@ Klik: "Zapisz treści 'O nas' (PL)"
 
 ## 📊 Przykład użycia
 
-### Chcę zmienić "500+" na "1000+":
+### Chcę zmienić "500+" na "1000+" i ustawić różne etykiety dla EN i PL:
 
 **Krok 1:** Wejdź na `/admin.html`  
 **Krok 2:** Przewiń do sekcji **"Edit About Page"**  
-**Krok 3:** Znajdź **"Our Impact Statistics (EN)"**  
-**Krok 4:** Zmień **"Stat 1 - Value"** z `500+` na `1000+`  
+**Krok 3:** Znajdź **"Our Impact Statistics (EN & PL)"**  
+**Krok 4:** W **"Statistic 1"** zmień:
+- **Value (Shared):** z `500+` na `1000+`
+- **Label (EN):** `Fashion Brands Launched`
+- **Label (PL):** `Uruchomionych Marek Modowych`  
 **Krok 5:** Kliknij **"Save About Content"**  
 **Krok 6:** Odśwież strony:
-- ✅ `/about.html` → zobaczysz "1000+"
-- ✅ `/success-stories.html` → zobaczysz "1000+"
+- ✅ `/about.html` → zobaczysz "1000+" z etykietą EN
+- ✅ `/success-stories.html` → zobaczysz "1000+" z etykietą EN
+- ✅ `/about-pl.html` → zobaczysz "1000+" z etykietą PL
+- ✅ `/success-stories-pl.html` → zobaczysz "1000+" z etykietą PL
 
-**To wszystko!** Jedna zmiana = aktualizacja na obu stronach! 🎉
+**To wszystko!** Jedna zmiana = aktualizacja na WSZYSTKICH stronach z odpowiednimi tłumaczeniami! 🎉
 
 ---
 
@@ -84,17 +81,23 @@ Klik: "Zapisz treści 'O nas' (PL)"
 
 ### Klucze localStorage:
 
-**Angielska wersja:**
-- `impactStat1Value`, `impactStat1Label`
-- `impactStat2Value`, `impactStat2Label`
-- `impactStat3Value`, `impactStat3Label`
-- `impactStat4Value`, `impactStat4Label`
+**Wartości (współdzielone EN & PL):**
+- `impactStat1Value`
+- `impactStat2Value`
+- `impactStat3Value`
+- `impactStat4Value`
 
-**Polska wersja:**
-- `plImpactStat1Value`, `plImpactStat1Label`
-- `plImpactStat2Value`, `plImpactStat2Label`
-- `plImpactStat3Value`, `plImpactStat3Label`
-- `plImpactStat4Value`, `plImpactStat4Label`
+**Etykiety angielskie:**
+- `impactStat1Label`
+- `impactStat2Label`
+- `impactStat3Label`
+- `impactStat4Label`
+
+**Etykiety polskie:**
+- `plImpactStat1Label`
+- `plImpactStat2Label`
+- `plImpactStat3Label`
+- `plImpactStat4Label`
 
 ### Strony które używają tych wartości:
 
@@ -112,23 +115,29 @@ Klik: "Zapisz treści 'O nas' (PL)"
 ### Zmienione pliki:
 
 1. **admin.html**
-   - ✅ Zmieniono tytuł sekcji: "Our Impact Statistics (EN)"
-   - ✅ Dodano info: "📍 These statistics are displayed on About page and Success Stories page."
-   - ✅ Usunięto duplikujące pola ze sekcji Success Stories (EN)
+   - ✅ Zmieniono strukturę sekcji: "Our Impact Statistics (EN & PL)"
+   - ✅ Każda statystyka ma teraz 3 pola: Value (Shared), Label (EN), Label (PL)
+   - ✅ Pola PL przeniesione z sekcji PL do sekcji EN dla łatwego zarządzania
+   - ✅ JavaScript zapisuje zarówno EN jak i PL etykiety przy kliknięciu "Save About Content"
+   - ✅ Dodano wizualne oddzielenie statystyk z szarym tłem
    - ✅ Dodano info w Success Stories: "ℹ️ Statistics for Success Stories are managed in the 'Our Impact Statistics' section above"
 
 2. **admin-pl.js**
-   - ✅ Usunięto inicjalizację `plSuccessStat*` (używamy teraz `plImpactStat*`)
-   - ✅ Usunięto ładowanie i zapisywanie pól `plSuccessStat*`
+   - ✅ Usunięto ładowanie i zapisywanie pól `plImpactStat*Label` (teraz zarządzane przez admin.html)
+   - ✅ Zachowano inicjalizację domyślnych wartości PL
+   - ✅ Dodano komentarze wyjaśniające nowy system
 
 3. **success-stories.html**
-   - ✅ Zmieniono ładowanie z `successStat*` na `impactStat*`
+   - ✅ Używa wartości `impactStat*Value` i etykiet `impactStat*Label`
 
 4. **success-stories-pl.html**
-   - ✅ Zmieniono ładowanie z `plSuccessStat*` na `plImpactStat*`
+   - ✅ Używa wartości `impactStat*Value` (współdzielone) i etykiet `plImpactStat*Label`
 
-5. **cms-data.json**
-   - ✅ Usunięto stare wartości `plSuccessStat*`
+5. **about.html**
+   - ✅ Używa wartości `impactStat*Value` i etykiet `impactStat*Label`
+
+6. **about-pl.html**
+   - ✅ Używa wartości `impactStat*Value` (współdzielone) i etykiet `plImpactStat*Label`
 
 ---
 
@@ -181,24 +190,36 @@ Klik: "Zapisz treści 'O nas' (PL)"
 1. Otwórz `/admin.html`
 2. Zaloguj się
 3. Przewiń do **"Edit About Page"**
-4. Znajdź **"Our Impact Statistics (EN)"** lub **"Statystyki 'Nasz Wpływ' (PL)"**
-5. Edytuj statystyki
-6. Kliknij **"Save About Content"** lub **"Zapisz treści 'O nas' (PL)"**
-7. Odśwież `/about.html` i `/success-stories.html` → **zmiana widoczna na obu!** ✅
+4. Znajdź **"Our Impact Statistics (EN & PL)"**
+5. Edytuj statystyki - każda ma 3 pola:
+   - **Value (Shared)** - wartość dla obu wersji językowych
+   - **Label (EN)** - etykieta po angielsku
+   - **Label (PL)** - etykieta po polsku
+6. Kliknij **"Save About Content"**
+7. Odśwież strony → **zmiana widoczna na WSZYSTKICH 4 stronach!** ✅
+   - `/about.html` (EN)
+   - `/about-pl.html` (PL)
+   - `/success-stories.html` (EN)
+   - `/success-stories-pl.html` (PL)
 
 ---
 
 ## 💡 Wskazówki
 
-- **Nie szukaj statystyk w sekcji Success Stories** - one teraz są zarządzane przez About!
-- **Widzisz info**: "ℹ️ Statistics for Success Stories are managed in the 'Our Impact Statistics' section above"
-- **Jedna zmiana** → automatyczna aktualizacja na **obu stronach** (About i Success Stories)
-- **Działa dla EN i PL** → pełna integracja
+- **Wszystkie statystyki w jednym miejscu** - zarządzaj EN i PL w sekcji "Edit About Page"
+- **Wartości współdzielone** - zmiana wartości automatycznie aktualizuje EN i PL
+- **Etykiety oddzielne** - możesz mieć różne tłumaczenia dla każdej wersji językowej
+- **Jedna zmiana** → automatyczna aktualizacja na **4 stronach** (About EN/PL i Success Stories EN/PL)
+- **Wizualne oddzielenie** - każda statystyka ma szare tło dla łatwej identyfikacji
 
 ---
 
 ## 🎉 Podsumowanie
 
-**Teraz masz jedną centralną sekcję "Our Impact Statistics"**, która aktualizuje statystyki na **obu stronach jednocześnie**!
+**Teraz masz jedną centralną sekcję "Our Impact Statistics (EN & PL)"**, która:
+- ✅ Aktualizuje statystyki na **4 stronach jednocześnie** (About EN/PL, Success Stories EN/PL)
+- ✅ Umożliwia **oddzielne etykiety** dla wersji angielskiej i polskiej
+- ✅ Współdzieli **wartości** między wersjami językowymi
+- ✅ Wszystko w **jednym miejscu** - nie musisz szukać w różnych sekcjach!
 
-**To znacznie upraszcza zarządzanie treścią i eliminuje ryzyko niespójności!** 🎯
+**To znacznie upraszcza zarządzanie treścią, eliminuje ryzyko niespójności i daje pełną kontrolę nad tłumaczeniami!** 🎯

--- a/admin-pl.js
+++ b/admin-pl.js
@@ -279,18 +279,10 @@ document.addEventListener('DOMContentLoaded', function() {
     ['admin-impact-title-pl','plImpactTitle','impactTitle'],
     ['admin-impact-subtitle-pl','plImpactSubtitle','impactSubtitle']
   ];
-  const impactStatsPairs = [
-    // Values are shared with EN version, only labels are translated
-    ['admin-impact-stat1-label-pl','plImpactStat1Label','impactStat1Label','Uruchomionych Marek Modowych'],
-    ['admin-impact-stat2-label-pl','plImpactStat2Label','impactStat2Label','Sprzedaż Marek'],
-    ['admin-impact-stat3-label-pl','plImpactStat3Label','impactStat3Label','Sprzedanych Produktów'],
-    ['admin-impact-stat4-label-pl','plImpactStat4Label','impactStat4Label','Wskaźnik Sukcesu']
-  ];
+  // Note: Impact statistics PL labels are now managed in the EN section (admin.html)
+  // and saved by the "Save About Content" button, so we don't load/save them here
   aboutPairs.forEach(function(p) {
     loadField(p[0], p[1], p[2]);
-  });
-  impactStatsPairs.forEach(function(p) {
-    loadField(p[0], p[1], p[2], p[3]);
   });
   // Add Values section fields (PL)
   const valuePairs = [
@@ -326,7 +318,7 @@ document.addEventListener('DOMContentLoaded', function() {
   if (saveAboutPl) {
     saveAboutPl.addEventListener('click', function() {
       saveFields(aboutPairs.map(item => [item[0], item[1]]));
-      saveFields(impactStatsPairs.map(item => [item[0], item[1]]));
+      // Note: Impact statistics PL labels are saved by "Save About Content" button in EN section
       saveFields(valuePairs.map(item => [item[0], item[1]]));
       saveFields(aboutCtaPairs.map(item => [item[0], item[1]]));
       const msg = document.getElementById('about-save-msg-pl');

--- a/admin.html
+++ b/admin.html
@@ -110,49 +110,83 @@
                 </div>
             </div>
             <!-- Our Impact Statistics Section - Used on About & Success Stories -->
-            <h4 class="text-lg font-semibold mt-6 mb-2">Our Impact Statistics</h4>
+            <h4 class="text-lg font-semibold mt-6 mb-2">Our Impact Statistics (EN & PL)</h4>
             <p class="text-sm text-gray-600 mb-3">📍 These statistics are displayed on <strong>About page</strong> and <strong>Success Stories page</strong>.</p>
-            <p class="text-sm text-blue-600 mb-3">ℹ️ <strong>Values are shared between EN and PL versions.</strong> Labels are translated separately below.</p>
+            <p class="text-sm text-blue-600 mb-3">ℹ️ <strong>Values are shared between EN and PL.</strong> Each stat has separate labels for EN and PL.</p>
             
-            <!-- Shared Values -->
-            <h5 class="text-md font-semibold mt-4 mb-2">Values (Shared for EN & PL)</h5>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                <div>
-                    <label for="admin-impact-stat1-value" class="block text-sm font-medium text-gray-700 mb-1">Stat 1 - Value</label>
-                    <input id="admin-impact-stat1-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="500+" />
-                </div>
-                <div>
-                    <label for="admin-impact-stat2-value" class="block text-sm font-medium text-gray-700 mb-1">Stat 2 - Value</label>
-                    <input id="admin-impact-stat2-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="$50M" />
-                </div>
-                <div>
-                    <label for="admin-impact-stat3-value" class="block text-sm font-medium text-gray-700 mb-1">Stat 3 - Value</label>
-                    <input id="admin-impact-stat3-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="2.4M" />
-                </div>
-                <div>
-                    <label for="admin-impact-stat4-value" class="block text-sm font-medium text-gray-700 mb-1">Stat 4 - Value</label>
-                    <input id="admin-impact-stat4-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="98%" />
+            <!-- Statistic 1 -->
+            <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
+                <h5 class="text-md font-semibold mb-3">Statistic 1</h5>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                        <label for="admin-impact-stat1-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
+                        <input id="admin-impact-stat1-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="500+" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat1-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
+                        <input id="admin-impact-stat1-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Fashion Brands Launched" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat1-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Label (PL)</label>
+                        <input id="admin-impact-stat1-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Uruchomionych Marek Modowych" />
+                    </div>
                 </div>
             </div>
             
-            <!-- Labels in EN -->
-            <h5 class="text-md font-semibold mt-4 mb-2">Labels (EN)</h5>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                <div>
-                    <label for="admin-impact-stat1-label" class="block text-sm font-medium text-gray-700 mb-1">Stat 1 - Label (EN)</label>
-                    <input id="admin-impact-stat1-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Fashion Brands Launched" />
+            <!-- Statistic 2 -->
+            <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
+                <h5 class="text-md font-semibold mb-3">Statistic 2</h5>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                        <label for="admin-impact-stat2-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
+                        <input id="admin-impact-stat2-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="$50M" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat2-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
+                        <input id="admin-impact-stat2-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="In Brand Sales" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat2-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Label (PL)</label>
+                        <input id="admin-impact-stat2-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Sprzedaż Marek" />
+                    </div>
                 </div>
-                <div>
-                    <label for="admin-impact-stat2-label" class="block text-sm font-medium text-gray-700 mb-1">Stat 2 - Label (EN)</label>
-                    <input id="admin-impact-stat2-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="In Brand Sales" />
+            </div>
+            
+            <!-- Statistic 3 -->
+            <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
+                <h5 class="text-md font-semibold mb-3">Statistic 3</h5>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                        <label for="admin-impact-stat3-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
+                        <input id="admin-impact-stat3-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="2.4M" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat3-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
+                        <input id="admin-impact-stat3-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Products Sold" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat3-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Label (PL)</label>
+                        <input id="admin-impact-stat3-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Sprzedanych Produktów" />
+                    </div>
                 </div>
-                <div>
-                    <label for="admin-impact-stat3-label" class="block text-sm font-medium text-gray-700 mb-1">Stat 3 - Label (EN)</label>
-                    <input id="admin-impact-stat3-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Products Sold" />
-                </div>
-                <div>
-                    <label for="admin-impact-stat4-label" class="block text-sm font-medium text-gray-700 mb-1">Stat 4 - Label (EN)</label>
-                    <input id="admin-impact-stat4-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Success Rate" />
+            </div>
+            
+            <!-- Statistic 4 -->
+            <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
+                <h5 class="text-md font-semibold mb-3">Statistic 4</h5>
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                        <label for="admin-impact-stat4-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
+                        <input id="admin-impact-stat4-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="98%" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat4-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
+                        <input id="admin-impact-stat4-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Success Rate" />
+                    </div>
+                    <div>
+                        <label for="admin-impact-stat4-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Label (PL)</label>
+                        <input id="admin-impact-stat4-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Wskaźnik Sukcesu" />
+                    </div>
                 </div>
             </div>
             <!-- About Values Section (EN) -->
@@ -998,31 +1032,8 @@
                     <input id="admin-impact-subtitle-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" />
                 </div>
             </div>
-            <!-- Our Impact Statistics Section (PL) - Used on About & Success Stories -->
-            <h4 class="text-lg font-semibold mt-6 mb-2">Statystyki "Nasz Wpływ" (PL)</h4>
-            <p class="text-sm text-gray-600 mb-3">📍 Te statystyki są wyświetlane na stronie <strong>O nas</strong> oraz <strong>Historie sukcesu</strong>.</p>
-            <p class="text-sm text-blue-600 mb-3">ℹ️ <strong>Wartości są współdzielone z wersją EN</strong> (edytuj je w sekcji EN powyżej). Tutaj tłumaczysz tylko etykiety.</p>
-            
-            <!-- Labels in PL -->
-            <h5 class="text-md font-semibold mt-4 mb-2">Etykiety (PL)</h5>
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                <div>
-                    <label for="admin-impact-stat1-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Statystyka 1 - Etykieta (PL)</label>
-                    <input id="admin-impact-stat1-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Uruchomionych Marek Modowych" />
-                </div>
-                <div>
-                    <label for="admin-impact-stat2-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Statystyka 2 - Etykieta (PL)</label>
-                    <input id="admin-impact-stat2-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Sprzedaż Marek" />
-                </div>
-                <div>
-                    <label for="admin-impact-stat3-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Statystyka 3 - Etykieta (PL)</label>
-                    <input id="admin-impact-stat3-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Sprzedanych Produktów" />
-                </div>
-                <div>
-                    <label for="admin-impact-stat4-label-pl" class="block text-sm font-medium text-gray-700 mb-1">Statystyka 4 - Etykieta (PL)</label>
-                    <input id="admin-impact-stat4-label-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Wskaźnik Sukcesu" />
-                </div>
-            </div>
+            <!-- Our Impact Statistics (PL) - Managed in EN section above -->
+            <p class="text-sm text-gray-500 mb-4">ℹ️ Statystyki "Nasz Wpływ" dla strony <strong>O nas</strong> i <strong>Historie sukcesu</strong> są zarządzane w sekcji <strong>"Our Impact Statistics (EN & PL)"</strong> powyżej (w sekcji EN "Edit About Page").</p>
             <!-- About Values Section (PL) -->
             <h4 class="text-lg font-semibold mt-6 mb-2">Sekcja Wartości (PL)</h4>
             <div class="mb-4 grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -1604,15 +1615,19 @@
         const teamSubtitleField = document.getElementById('admin-team-subtitle');
         const impactTitleField = document.getElementById('admin-impact-title');
         const impactSubtitleField = document.getElementById('admin-impact-subtitle');
-        // Impact statistics fields (EN)
+        // Impact statistics fields (EN & PL)
         const impactStat1ValueField = document.getElementById('admin-impact-stat1-value');
         const impactStat1LabelField = document.getElementById('admin-impact-stat1-label');
+        const impactStat1LabelPlField = document.getElementById('admin-impact-stat1-label-pl');
         const impactStat2ValueField = document.getElementById('admin-impact-stat2-value');
         const impactStat2LabelField = document.getElementById('admin-impact-stat2-label');
+        const impactStat2LabelPlField = document.getElementById('admin-impact-stat2-label-pl');
         const impactStat3ValueField = document.getElementById('admin-impact-stat3-value');
         const impactStat3LabelField = document.getElementById('admin-impact-stat3-label');
+        const impactStat3LabelPlField = document.getElementById('admin-impact-stat3-label-pl');
         const impactStat4ValueField = document.getElementById('admin-impact-stat4-value');
         const impactStat4LabelField = document.getElementById('admin-impact-stat4-label');
+        const impactStat4LabelPlField = document.getElementById('admin-impact-stat4-label-pl');
         // Values section fields (EN)
         const valuesTitleField = document.getElementById('admin-values-title');
         const valuesSubtitleField = document.getElementById('admin-values-subtitle');
@@ -1649,15 +1664,19 @@
         teamSubtitleField.value = localStorage.getItem('teamSubtitle') || 'Our team combines decades of experience in fashion manufacturing, logistics, retail, and technology to support your brand\'s success.';
         impactTitleField.value = localStorage.getItem('impactTitle') || 'Our Impact';
         impactSubtitleField.value = localStorage.getItem('impactSubtitle') || 'Real results from real influencers who\'ve transformed their passion into profitable fashion brands.';
-        // Impact statistics defaults (EN)
+        // Impact statistics defaults (EN & PL)
         impactStat1ValueField.value = localStorage.getItem('impactStat1Value') || '500+';
         impactStat1LabelField.value = localStorage.getItem('impactStat1Label') || 'Fashion Brands Launched';
+        impactStat1LabelPlField.value = localStorage.getItem('plImpactStat1Label') || 'Uruchomionych Marek Modowych';
         impactStat2ValueField.value = localStorage.getItem('impactStat2Value') || '$50M';
         impactStat2LabelField.value = localStorage.getItem('impactStat2Label') || 'In Brand Sales';
+        impactStat2LabelPlField.value = localStorage.getItem('plImpactStat2Label') || 'Sprzedaż Marek';
         impactStat3ValueField.value = localStorage.getItem('impactStat3Value') || '2.4M';
         impactStat3LabelField.value = localStorage.getItem('impactStat3Label') || 'Products Sold';
+        impactStat3LabelPlField.value = localStorage.getItem('plImpactStat3Label') || 'Sprzedanych Produktów';
         impactStat4ValueField.value = localStorage.getItem('impactStat4Value') || '98%';
         impactStat4LabelField.value = localStorage.getItem('impactStat4Label') || 'Success Rate';
+        impactStat4LabelPlField.value = localStorage.getItem('plImpactStat4Label') || 'Wskaźnik Sukcesu';
         // Values section defaults (EN)
         valuesTitleField.value = localStorage.getItem('valuesTitle') || 'Our Values';
         valuesSubtitleField.value = localStorage.getItem('valuesSubtitle') || 'The principles that guide everything we do and drive every decision we make.';
@@ -1688,15 +1707,19 @@
             localStorage.setItem('teamSubtitle', teamSubtitleField.value);
             localStorage.setItem('impactTitle', impactTitleField.value);
             localStorage.setItem('impactSubtitle', impactSubtitleField.value);
-            // Save Impact statistics (EN)
+            // Save Impact statistics (EN & PL)
             localStorage.setItem('impactStat1Value', impactStat1ValueField.value);
             localStorage.setItem('impactStat1Label', impactStat1LabelField.value);
+            localStorage.setItem('plImpactStat1Label', impactStat1LabelPlField.value);
             localStorage.setItem('impactStat2Value', impactStat2ValueField.value);
             localStorage.setItem('impactStat2Label', impactStat2LabelField.value);
+            localStorage.setItem('plImpactStat2Label', impactStat2LabelPlField.value);
             localStorage.setItem('impactStat3Value', impactStat3ValueField.value);
             localStorage.setItem('impactStat3Label', impactStat3LabelField.value);
+            localStorage.setItem('plImpactStat3Label', impactStat3LabelPlField.value);
             localStorage.setItem('impactStat4Value', impactStat4ValueField.value);
             localStorage.setItem('impactStat4Label', impactStat4LabelField.value);
+            localStorage.setItem('plImpactStat4Label', impactStat4LabelPlField.value);
             // Save Values section (EN)
             localStorage.setItem('valuesTitle', valuesTitleField.value);
             localStorage.setItem('valuesSubtitle', valuesSubtitleField.value);


### PR DESCRIPTION
Consolidate Impact Statistics EN and PL label management into a single admin section to improve content editing clarity.

The previous CMS design separated English and Polish label fields into distinct, distant sections, making it difficult for users to manage translations effectively. This change brings both language labels for each statistic together, simplifying the editing process.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ece3123-8d49-48b9-859f-a0319293d205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ece3123-8d49-48b9-859f-a0319293d205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

