### PR TITLE
Investigate cms front-end display issue

### DIFF
--- a/admin-pl.js
+++ b/admin-pl.js
@@ -24,14 +24,11 @@ document.addEventListener('DOMContentLoaded', function() {
   initDefaultIfEmpty('plTeamSubtitle', 'Nasz zespół łączy dekady doświadczenia w produkcji mody, logistyce, handlu detalicznym i technologii, aby wspierać sukces Twojej marki.');
   initDefaultIfEmpty('plImpactTitle', 'Nasz Wpływ');
   initDefaultIfEmpty('plImpactSubtitle', 'Rzeczywiste wyniki od prawdziwych influencerów, którzy przekształcili swoją pasję w dochodowe marki modowe.');
-  // Impact Statistics Values and Labels (PL)
-  initDefaultIfEmpty('plImpactStat1Value', '500+');
+  // Impact Statistics Labels (PL) - Values are shared with EN version (impactStat*Value)
+  // Note: Values are managed in admin.html, only PL labels need defaults here
   initDefaultIfEmpty('plImpactStat1Label', 'Uruchomionych Marek Modowych');
-  initDefaultIfEmpty('plImpactStat2Value', '$50M');
   initDefaultIfEmpty('plImpactStat2Label', 'Sprzedaż Marek');
-  initDefaultIfEmpty('plImpactStat3Value', '2,4M');
   initDefaultIfEmpty('plImpactStat3Label', 'Sprzedanych Produktów');
-  initDefaultIfEmpty('plImpactStat4Value', '98%');
   initDefaultIfEmpty('plImpactStat4Label', 'Wskaźnik Sukcesu');
   initDefaultIfEmpty('plValuesTitle', 'Nasze Wartości');
   initDefaultIfEmpty('plValuesSubtitle', 'Zasady, które kierują wszystkim, co robimy i napędzają każdą podjętą przez nas decyzję.');

--- a/admin.html
+++ b/admin.html
@@ -112,22 +112,16 @@
             <!-- Our Impact Statistics Section - Used on About & Success Stories -->
             <h4 class="text-lg font-semibold mt-6 mb-2">Our Impact Statistics (EN & PL)</h4>
             <p class="text-sm text-gray-600 mb-3">📍 These statistics are displayed on <strong>About page</strong> and <strong>Success Stories page</strong>.</p>
-            <p class="text-sm text-blue-600 mb-3">ℹ️ Each stat has separate <strong>Value (EN)</strong>, <strong>Value (PL)</strong>, <strong>Label (EN)</strong>, and <strong>Label (PL)</strong>.</p>
+            <p class="text-sm text-blue-600 mb-3">ℹ️ Each stat has one <strong>Value (Shared)</strong> for both EN & PL, with separate <strong>Label (EN)</strong> and <strong>Label (PL)</strong>.</p>
             
             <!-- Statistic 1 -->
             <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
                 <h5 class="text-md font-semibold mb-3">Statistic 1</h5>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div>
-                        <label for="admin-impact-stat1-value" class="block text-sm font-medium text-gray-700 mb-1">Value (EN)</label>
+                        <label for="admin-impact-stat1-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
                         <input id="admin-impact-stat1-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="500+" />
                     </div>
-                    <div>
-                        <label for="admin-impact-stat1-value-pl" class="block text-sm font-medium text-gray-700 mb-1">Value (PL)</label>
-                        <input id="admin-impact-stat1-value-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="500+" />
-                    </div>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label for="admin-impact-stat1-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
                         <input id="admin-impact-stat1-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Fashion Brands Launched" />
@@ -142,17 +136,11 @@
             <!-- Statistic 2 -->
             <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
                 <h5 class="text-md font-semibold mb-3">Statistic 2</h5>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div>
-                        <label for="admin-impact-stat2-value" class="block text-sm font-medium text-gray-700 mb-1">Value (EN)</label>
+                        <label for="admin-impact-stat2-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
                         <input id="admin-impact-stat2-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="$50M" />
                     </div>
-                    <div>
-                        <label for="admin-impact-stat2-value-pl" class="block text-sm font-medium text-gray-700 mb-1">Value (PL)</label>
-                        <input id="admin-impact-stat2-value-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="$50M" />
-                    </div>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label for="admin-impact-stat2-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
                         <input id="admin-impact-stat2-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="In Brand Sales" />
@@ -167,17 +155,11 @@
             <!-- Statistic 3 -->
             <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
                 <h5 class="text-md font-semibold mb-3">Statistic 3</h5>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div>
-                        <label for="admin-impact-stat3-value" class="block text-sm font-medium text-gray-700 mb-1">Value (EN)</label>
+                        <label for="admin-impact-stat3-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
                         <input id="admin-impact-stat3-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="2.4M" />
                     </div>
-                    <div>
-                        <label for="admin-impact-stat3-value-pl" class="block text-sm font-medium text-gray-700 mb-1">Value (PL)</label>
-                        <input id="admin-impact-stat3-value-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="2,4M" />
-                    </div>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label for="admin-impact-stat3-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
                         <input id="admin-impact-stat3-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Products Sold" />
@@ -192,17 +174,11 @@
             <!-- Statistic 4 -->
             <div class="border border-gray-300 rounded-lg p-4 mb-4 bg-gray-50">
                 <h5 class="text-md font-semibold mb-3">Statistic 4</h5>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-3">
+                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <div>
-                        <label for="admin-impact-stat4-value" class="block text-sm font-medium text-gray-700 mb-1">Value (EN)</label>
+                        <label for="admin-impact-stat4-value" class="block text-sm font-medium text-gray-700 mb-1">Value (Shared)</label>
                         <input id="admin-impact-stat4-value" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="98%" />
                     </div>
-                    <div>
-                        <label for="admin-impact-stat4-value-pl" class="block text-sm font-medium text-gray-700 mb-1">Value (PL)</label>
-                        <input id="admin-impact-stat4-value-pl" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="98%" />
-                    </div>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label for="admin-impact-stat4-label" class="block text-sm font-medium text-gray-700 mb-1">Label (EN)</label>
                         <input id="admin-impact-stat4-label" type="text" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black" placeholder="Success Rate" />
@@ -1639,21 +1615,17 @@
         const teamSubtitleField = document.getElementById('admin-team-subtitle');
         const impactTitleField = document.getElementById('admin-impact-title');
         const impactSubtitleField = document.getElementById('admin-impact-subtitle');
-        // Impact statistics fields (EN & PL)
+        // Impact statistics fields (EN & PL) - Values are shared, labels are separate
         const impactStat1ValueField = document.getElementById('admin-impact-stat1-value');
-        const impactStat1ValuePlField = document.getElementById('admin-impact-stat1-value-pl');
         const impactStat1LabelField = document.getElementById('admin-impact-stat1-label');
         const impactStat1LabelPlField = document.getElementById('admin-impact-stat1-label-pl');
         const impactStat2ValueField = document.getElementById('admin-impact-stat2-value');
-        const impactStat2ValuePlField = document.getElementById('admin-impact-stat2-value-pl');
         const impactStat2LabelField = document.getElementById('admin-impact-stat2-label');
         const impactStat2LabelPlField = document.getElementById('admin-impact-stat2-label-pl');
         const impactStat3ValueField = document.getElementById('admin-impact-stat3-value');
-        const impactStat3ValuePlField = document.getElementById('admin-impact-stat3-value-pl');
         const impactStat3LabelField = document.getElementById('admin-impact-stat3-label');
         const impactStat3LabelPlField = document.getElementById('admin-impact-stat3-label-pl');
         const impactStat4ValueField = document.getElementById('admin-impact-stat4-value');
-        const impactStat4ValuePlField = document.getElementById('admin-impact-stat4-value-pl');
         const impactStat4LabelField = document.getElementById('admin-impact-stat4-label');
         const impactStat4LabelPlField = document.getElementById('admin-impact-stat4-label-pl');
         // Values section fields (EN)
@@ -1692,21 +1664,17 @@
         teamSubtitleField.value = localStorage.getItem('teamSubtitle') || 'Our team combines decades of experience in fashion manufacturing, logistics, retail, and technology to support your brand\'s success.';
         impactTitleField.value = localStorage.getItem('impactTitle') || 'Our Impact';
         impactSubtitleField.value = localStorage.getItem('impactSubtitle') || 'Real results from real influencers who\'ve transformed their passion into profitable fashion brands.';
-        // Impact statistics defaults (EN & PL)
+        // Impact statistics defaults (EN & PL) - Values are shared, labels are separate
         impactStat1ValueField.value = localStorage.getItem('impactStat1Value') || '500+';
-        impactStat1ValuePlField.value = localStorage.getItem('plImpactStat1Value') || '500+';
         impactStat1LabelField.value = localStorage.getItem('impactStat1Label') || 'Fashion Brands Launched';
         impactStat1LabelPlField.value = localStorage.getItem('plImpactStat1Label') || 'Uruchomionych Marek Modowych';
         impactStat2ValueField.value = localStorage.getItem('impactStat2Value') || '$50M';
-        impactStat2ValuePlField.value = localStorage.getItem('plImpactStat2Value') || '$50M';
         impactStat2LabelField.value = localStorage.getItem('impactStat2Label') || 'In Brand Sales';
         impactStat2LabelPlField.value = localStorage.getItem('plImpactStat2Label') || 'Sprzedaż Marek';
         impactStat3ValueField.value = localStorage.getItem('impactStat3Value') || '2.4M';
-        impactStat3ValuePlField.value = localStorage.getItem('plImpactStat3Value') || '2,4M';
         impactStat3LabelField.value = localStorage.getItem('impactStat3Label') || 'Products Sold';
         impactStat3LabelPlField.value = localStorage.getItem('plImpactStat3Label') || 'Sprzedanych Produktów';
         impactStat4ValueField.value = localStorage.getItem('impactStat4Value') || '98%';
-        impactStat4ValuePlField.value = localStorage.getItem('plImpactStat4Value') || '98%';
         impactStat4LabelField.value = localStorage.getItem('impactStat4Label') || 'Success Rate';
         impactStat4LabelPlField.value = localStorage.getItem('plImpactStat4Label') || 'Wskaźnik Sukcesu';
         // Values section defaults (EN)
@@ -1739,21 +1707,17 @@
             localStorage.setItem('teamSubtitle', teamSubtitleField.value);
             localStorage.setItem('impactTitle', impactTitleField.value);
             localStorage.setItem('impactSubtitle', impactSubtitleField.value);
-            // Save Impact statistics (EN & PL)
+            // Save Impact statistics (EN & PL) - Values are shared, labels are separate
             localStorage.setItem('impactStat1Value', impactStat1ValueField.value);
-            localStorage.setItem('plImpactStat1Value', impactStat1ValuePlField.value);
             localStorage.setItem('impactStat1Label', impactStat1LabelField.value);
             localStorage.setItem('plImpactStat1Label', impactStat1LabelPlField.value);
             localStorage.setItem('impactStat2Value', impactStat2ValueField.value);
-            localStorage.setItem('plImpactStat2Value', impactStat2ValuePlField.value);
             localStorage.setItem('impactStat2Label', impactStat2LabelField.value);
             localStorage.setItem('plImpactStat2Label', impactStat2LabelPlField.value);
             localStorage.setItem('impactStat3Value', impactStat3ValueField.value);
-            localStorage.setItem('plImpactStat3Value', impactStat3ValuePlField.value);
             localStorage.setItem('impactStat3Label', impactStat3LabelField.value);
             localStorage.setItem('plImpactStat3Label', impactStat3LabelPlField.value);
             localStorage.setItem('impactStat4Value', impactStat4ValueField.value);
-            localStorage.setItem('plImpactStat4Value', impactStat4ValuePlField.value);
             localStorage.setItem('impactStat4Label', impactStat4LabelField.value);
             localStorage.setItem('plImpactStat4Label', impactStat4LabelPlField.value);
             // Save Values section (EN)


### PR DESCRIPTION
Remove redundant `plImpactStat*Value` fields and logic to fix a data inconsistency where Polish impact statistics changes were not reflecting on the frontend.

The CMS was saving Polish impact statistics values to `plImpactStat*Value` keys, but the frontend pages were incorrectly configured to read shared `impactStat*Value` keys for both English and Polish versions. This PR aligns the admin panel's saving mechanism and default initializations with the frontend's reading logic, ensuring that changes made in the CMS for Polish statistics are correctly displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7e2662a-0205-4238-846f-44f89e5ca457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7e2662a-0205-4238-846f-44f89e5ca457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

