### PR TITLE
Fix success stories hide button

### DIFF
--- a/SUCCESS_STORIES_TOGGLE_FIX.md
+++ b/SUCCESS_STORIES_TOGGLE_FIX.md
@@ -1,0 +1,73 @@
+# Success Stories Toggle - Naprawa
+
+## Problem
+Przycisk w CMS do ukrywania/pokazywania Success Stories był już dodany, ale nie działał poprawnie. Linki do Success Stories nie były ukrywane po wyłączeniu przełącznika w panelu administracyjnym.
+
+## Przyczyna
+Funkcja `updateSuccessStoriesVisibility()` ukrywała tylko elementy `<a>`, ale w stopce linki były opakowane w elementy `<li>`. Ukrywanie tylko linku (`<a>`) pozostawiało widoczny element listy, przez co linki nadal były widoczne (lub zostawiały puste miejsce).
+
+## Rozwiązanie
+Zaktualizowano funkcję `updateSuccessStoriesVisibility()` w obu plikach:
+- `/workspace/auth.js` (dla stron w folderze głównym)
+- `/workspace/landing/auth.js` (dla stron w folderze landing)
+
+### Zmiany w kodzie:
+
+```javascript
+function updateSuccessStoriesVisibility() {
+  const showSuccessStories = localStorage.getItem('showSuccessStories') !== 'false';
+  const allLinks = document.querySelectorAll('a[href*="success-stories"]');
+  
+  allLinks.forEach(link => {
+    // Sprawdź czy link jest w elemencie <li> (np. w stopce)
+    const parentLi = link.closest('li');
+    const elementToHide = parentLi || link;
+    
+    if (showSuccessStories) {
+      elementToHide.style.display = '';
+    } else {
+      elementToHide.style.display = 'none';
+    }
+  });
+}
+```
+
+### Kluczowe zmiany:
+1. Dodano `link.closest('li')` aby znaleźć rodzica `<li>` jeśli istnieje
+2. Używamy `parentLi` do ukrycia jeśli istnieje, w przeciwnym razie ukrywamy sam link
+3. Dodano wywołanie `updateSuccessStoriesVisibility()` w funkcji `updateNav()` w `/workspace/auth.js`
+
+## Jak to działa teraz
+
+1. Administrator wchodzi do panelu CMS (`admin.html`)
+2. W sekcji "Navigation Settings" znajduje się przełącznik "Success Stories Page"
+3. Po wyłączeniu przełącznika (unchecked):
+   - Wartość w localStorage: `showSuccessStories = 'false'`
+   - Funkcja `updateSuccessStoriesVisibility()` znajduje wszystkie linki zawierające "success-stories"
+   - Dla każdego linku sprawdza czy jest w `<li>` i ukrywa odpowiedni element
+4. Po włączeniu przełącznika (checked):
+   - Wartość w localStorage: `showSuccessStories = 'true'`
+   - Wszystkie linki do Success Stories są ponownie widoczne
+
+## Lokalizacje gdzie linki są ukrywane
+
+Na każdej stronie znajdują się zazwyczaj 3 linki do Success Stories:
+1. **Nawigacja desktop** - link bezpośredni w menu górnym
+2. **Nawigacja mobile** - link w rozwijanym menu mobilnym
+3. **Stopka** - link w liście (`<li>`) w dolnej części strony
+
+Wszystkie te linki są teraz poprawnie ukrywane/pokazywane.
+
+## Testowanie
+
+Aby przetestować funkcjonalność:
+1. Otwórz panel CMS: `landing/admin.html`
+2. Zaloguj się jako administrator
+3. Wyłącz przełącznik "Success Stories Page"
+4. Odwiedź dowolną stronę (np. `landing/index.html`, `landing/index-pl.html`)
+5. Sprawdź czy linki Success Stories są ukryte w:
+   - Menu górnym (desktop)
+   - Menu mobilnym
+   - Stopce strony
+6. Wróć do panelu CMS i włącz przełącznik
+7. Odśwież stronę - linki powinny być znowu widoczne

--- a/auth.js
+++ b/auth.js
@@ -34,6 +34,28 @@ function logout() {
   }
 }
 
+// Update visibility of Success Stories navigation links based on admin settings
+function updateSuccessStoriesVisibility() {
+  // Check if Success Stories should be visible (default is true if not set)
+  const showSuccessStories = localStorage.getItem('showSuccessStories') !== 'false';
+  
+  // Find all Success Stories links in desktop and mobile navigation
+  // We need to find them by href since they don't have specific IDs
+  const allLinks = document.querySelectorAll('a[href*="success-stories"]');
+  
+  allLinks.forEach(link => {
+    // Check if the link is inside an <li> element (e.g., in footer)
+    const parentLi = link.closest('li');
+    const elementToHide = parentLi || link;
+    
+    if (showSuccessStories) {
+      elementToHide.style.display = '';
+    } else {
+      elementToHide.style.display = 'none';
+    }
+  });
+}
+
 function updateNav() {
   const calcLink = document.getElementById('nav-calculator');
   const docLink = document.getElementById('nav-documents');
@@ -51,6 +73,9 @@ function updateNav() {
   const loginLinkMobile = document.getElementById('nav-login-mobile');
   const logoutLinkMobile = document.getElementById('nav-logout-mobile');
   const adminLinkMobile = document.getElementById('nav-admin-mobile');
+
+  // Handle Success Stories visibility based on admin settings
+  updateSuccessStoriesVisibility();
 
     if (isLoggedIn()) {
         // show documents and logout links

--- a/landing/auth.js
+++ b/landing/auth.js
@@ -38,10 +38,14 @@ function updateSuccessStoriesVisibility() {
   const allLinks = document.querySelectorAll('a[href*="success-stories"]');
   
   allLinks.forEach(link => {
+    // Check if the link is inside an <li> element (e.g., in footer)
+    const parentLi = link.closest('li');
+    const elementToHide = parentLi || link;
+    
     if (showSuccessStories) {
-      link.style.display = '';
+      elementToHide.style.display = '';
     } else {
-      link.style.display = 'none';
+      elementToHide.style.display = 'none';
     }
   });
 }


### PR DESCRIPTION
Fix the 'Success Stories' toggle in CMS to correctly hide links by targeting their parent `<li>` elements.

The previous implementation only applied `display: none` to the `<a>` tags. In cases where links were nested within `<li>` elements (e.g., in the footer), this left the `<li>` visible, resulting in partially hidden links or visible empty spacing. This change ensures the entire `<li>` element is hidden, providing a complete visual hide.

---
<a href="https://cursor.com/background-agent?bcId=bc-3dc18b67-e583-45ab-92e2-f906d2263e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3dc18b67-e583-45ab-92e2-f906d2263e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

