### PR TITLE
Verify success stories hide confirmation

### DIFF
--- a/DIAGNOSTYKA_SUCCESS_STORIES.md
+++ b/DIAGNOSTYKA_SUCCESS_STORIES.md
@@ -1,0 +1,203 @@
+# Diagnostyka problemu z ukrywaniem Success Stories
+
+## Szybka diagnoza w konsoli przeglądarki
+
+### Krok 1: Otwórz konsolę
+1. Otwórz dowolną stronę (np. `/landing/index.html` lub `/landing/index-pl.html`)
+2. Naciśnij **F12** aby otworzyć narzędzia deweloperskie
+3. Przejdź do zakładki **Console**
+
+### Krok 2: Sprawdź obecny stan
+
+Wklej do konsoli i naciśnij Enter:
+
+```javascript
+console.log('Wartość showSuccessStories:', localStorage.getItem('showSuccessStories'));
+```
+
+**Wyniki:**
+- `null` lub `"true"` = Success Stories powinny być WIDOCZNE
+- `"false"` = Success Stories powinny być UKRYTE
+
+### Krok 3: Znajdź wszystkie linki Success Stories
+
+```javascript
+const links = document.querySelectorAll('a[href*="success-stories"]');
+console.log('Znaleziono linków:', links.length);
+links.forEach((link, i) => {
+    const parentLi = link.closest('li');
+    const element = parentLi || link;
+    console.log(`Link ${i+1}:`, link.textContent.trim(), 
+                '| display:', element.style.display || 'default',
+                '| w <li>:', !!parentLi);
+});
+```
+
+**Oczekiwane wyniki:**
+- Powinno znaleźć 3 linki (desktop menu, mobile menu, footer)
+- Jeśli `showSuccessStories = "false"`, wszystkie powinny mieć `display: "none"`
+
+### Krok 4: Ręczne ukrycie (test)
+
+```javascript
+localStorage.setItem('showSuccessStories', 'false');
+location.reload();
+```
+
+### Krok 5: Ręczne pokazanie (test)
+
+```javascript
+localStorage.setItem('showSuccessStories', 'true');
+location.reload();
+```
+
+---
+
+## Pełny skrypt diagnostyczny
+
+Wklej całość do konsoli:
+
+```javascript
+(function diagnose() {
+    console.log('=== DIAGNOSTYKA SUCCESS STORIES ===');
+    
+    // 1. Sprawdź localStorage
+    const setting = localStorage.getItem('showSuccessStories');
+    console.log('1. localStorage.showSuccessStories:', setting);
+    console.log('   Interpretacja:', setting !== 'false' ? 'WIDOCZNE ✅' : 'UKRYTE ❌');
+    
+    // 2. Znajdź linki
+    const links = document.querySelectorAll('a[href*="success-stories"]');
+    console.log('\n2. Znalezione linki:', links.length);
+    
+    if (links.length === 0) {
+        console.warn('   ⚠️ PROBLEM: Nie znaleziono żadnych linków!');
+        return;
+    }
+    
+    // 3. Szczegóły każdego linku
+    console.log('\n3. Szczegóły linków:');
+    links.forEach((link, i) => {
+        const parentLi = link.closest('li');
+        const element = parentLi || link;
+        const computedDisplay = window.getComputedStyle(element).display;
+        
+        console.log(`   Link #${i+1}:`);
+        console.log('     - Tekst:', link.textContent.trim());
+        console.log('     - href:', link.getAttribute('href'));
+        console.log('     - W <li>:', !!parentLi);
+        console.log('     - style.display:', element.style.display || '(pusty)');
+        console.log('     - computed display:', computedDisplay);
+        console.log('     - Widoczny:', computedDisplay !== 'none' ? '✅' : '❌');
+    });
+    
+    // 4. Sprawdź czy funkcja istnieje
+    console.log('\n4. Funkcja updateSuccessStoriesVisibility:');
+    console.log('   Istnieje:', typeof updateSuccessStoriesVisibility === 'function' ? '✅' : '❌ BRAK!');
+    
+    // 5. Test funkcji
+    if (typeof updateSuccessStoriesVisibility === 'function') {
+        console.log('\n5. Test wywołania funkcji...');
+        updateSuccessStoriesVisibility();
+        console.log('   ✅ Funkcja została wykonana');
+        
+        // Sprawdź ponownie stan linków
+        console.log('\n6. Stan po wywołaniu funkcji:');
+        links.forEach((link, i) => {
+            const parentLi = link.closest('li');
+            const element = parentLi || link;
+            const computedDisplay = window.getComputedStyle(element).display;
+            console.log(`   Link #${i+1}: ${computedDisplay !== 'none' ? '✅ WIDOCZNY' : '❌ UKRYTY'}`);
+        });
+    }
+    
+    // 7. Sprawdź czy auth.js jest załadowany
+    console.log('\n7. Inne funkcje z auth.js:');
+    console.log('   - isLoggedIn:', typeof isLoggedIn === 'function' ? '✅' : '❌');
+    console.log('   - updateNav:', typeof updateNav === 'function' ? '✅' : '❌');
+    
+    console.log('\n=== KONIEC DIAGNOSTYKI ===');
+})();
+```
+
+---
+
+## Możliwe problemy i rozwiązania
+
+### Problem 1: Funkcja nie istnieje
+**Objawy:** `typeof updateSuccessStoriesVisibility === 'undefined'`
+
+**Przyczyna:** Plik `auth.js` nie został załadowany
+
+**Rozwiązanie:** Sprawdź czy na dole strony jest:
+```html
+<script src="auth.js"></script>
+```
+
+### Problem 2: Linki nie zostały znalezione
+**Objawy:** `links.length === 0`
+
+**Przyczyna:** Strona nie ma linków do Success Stories lub używa innego wzorca URL
+
+**Rozwiązanie:** Sprawdź czy są linki zawierające "success-stories" w href
+
+### Problem 3: Funkcja nie jest wywoływana
+**Objawy:** Linki mają `style.display = ""` (pusty) zamiast `"none"`
+
+**Przyczyna:** Funkcja `updateSuccessStoriesVisibility()` nie została wywołana przy ładowaniu strony
+
+**Rozwiązanie:** Sprawdź czy funkcja `updateNav()` wywołuje `updateSuccessStoriesVisibility()`
+
+### Problem 4: Ustawienie nie jest zapisywane
+**Objawy:** Po odświeżeniu admin.html przełącznik wraca do stanu włączonego
+
+**Przyczyna:** localStorage może być zablokowany lub wyczyszczony
+
+**Rozwiązanie:**
+1. Sprawdź czy localStorage działa: `localStorage.setItem('test', '123'); localStorage.getItem('test');`
+2. Sprawdź ustawienia przeglądarki (cookies i localStorage muszą być włączone)
+
+---
+
+## Szybkie akcje naprawcze
+
+### Wymuszenie ukrycia (obejście)
+```javascript
+// Ustaw na "false" i odśwież
+localStorage.setItem('showSuccessStories', 'false');
+location.reload();
+```
+
+### Wymuszenie pokazania
+```javascript
+// Ustaw na "true" i odśwież
+localStorage.setItem('showSuccessStories', 'true');
+location.reload();
+```
+
+### Reset do domyślnego stanu
+```javascript
+// Usuń ustawienie (domyślnie będą widoczne)
+localStorage.removeItem('showSuccessStories');
+location.reload();
+```
+
+### Ukryj natychmiastowo bez odświeżania
+```javascript
+document.querySelectorAll('a[href*="success-stories"]').forEach(link => {
+    const parentLi = link.closest('li');
+    const element = parentLi || link;
+    element.style.display = 'none';
+});
+```
+
+---
+
+## Kontakt z deweloperem
+
+Jeśli problem nadal występuje, uruchom pełny skrypt diagnostyczny i wyślij wyniki (skopiuj z konsoli).
+
+Przydatne informacje:
+- Przeglądarka i wersja: `navigator.userAgent`
+- Czy localStorage działa: `typeof Storage !== "undefined"`
+- URL strony: `window.location.href`

--- a/INSTRUKCJA_TESTOWANIA_SUCCESS_STORIES.md
+++ b/INSTRUKCJA_TESTOWANIA_SUCCESS_STORIES.md
@@ -1,0 +1,86 @@
+# Instrukcja: Jak ukryć zakładkę Success Stories
+
+## Krok po kroku:
+
+### 1. Wyłącz zakładkę Success Stories w CMS
+1. Otwórz panel administracyjny: `/landing/admin.html`
+2. Zaloguj się jako administrator
+3. Na górze strony znajdziesz sekcję **"Navigation Settings"** (niebieskie tło)
+4. Kliknij w przełącznik **"Success Stories Page"** aby go WYŁĄCZYĆ
+5. Napis przy przełączniku zmieni się z "Visible" na "**Hidden**"
+6. Pojawi się komunikat: "Navigation settings saved automatically"
+
+✅ **Gotowe! Zmiana została zapisana.**
+
+---
+
+### 2. Sprawdź efekt na stronach
+
+**WAŻNE:** Musisz **odświeżyć strony** aby zobaczyć efekt!
+
+#### Sprawdź stronę angielską:
+1. Otwórz `/landing/index.html` w nowej karcie (lub odśwież jeśli już ją masz otwartą - **F5**)
+2. Sprawdź czy zakładka "Success Stories" zniknęła z:
+   - Menu górnego (desktop)
+   - Menu mobilnego (hamburger)
+   - Stopki strony
+
+#### Sprawdź stronę polską:
+1. Otwórz `/landing/index-pl.html` w nowej karcie (lub odśwież - **F5**)
+2. Sprawdź czy zakładka "Success Stories" zniknęła z:
+   - Menu górnego (desktop)
+   - Menu mobilnego (hamburger)
+   - Stopki strony
+
+---
+
+### 3. Jak włączyć z powrotem?
+
+1. Wróć do `/landing/admin.html`
+2. Kliknij w przełącznik **"Success Stories Page"** aby go WŁĄCZYĆ
+3. Napis zmieni się na "**Visible**"
+4. Odśwież strony (`F5`) - zakładka powinna się pojawić
+
+---
+
+## Dlaczego muszę odświeżać strony?
+
+Przełącznik zapisuje ustawienie w **localStorage** przeglądarki. JavaScript na każdej stronie:
+- Czyta to ustawienie przy załadowaniu strony (funkcja `updateSuccessStoriesVisibility()`)
+- Ukrywa lub pokazuje wszystkie linki do Success Stories
+
+Strony które są już załadowane **nie wiedzą** o zmianie dopóki ich nie odświeżysz.
+
+---
+
+## Nie musisz:
+- ❌ Wciskać żadnego przycisku "Publikuj"
+- ❌ Zapisywać ręcznie - wszystko dzieje się automatycznie
+- ❌ Wylogowywać się i logować ponownie
+
+## Musisz tylko:
+- ✅ Kliknąć przełącznik
+- ✅ **Odświeżyć strony** gdzie chcesz zobaczyć efekt (F5)
+
+---
+
+## Debugowanie
+
+Jeśli nadal nie działa, sprawdź w konsoli przeglądarki (F12 → Console):
+
+```javascript
+// Sprawdź wartość ustawienia
+localStorage.getItem('showSuccessStories')
+// Powinno zwrócić: 'false' (ukryte) lub 'true' (widoczne)
+```
+
+Możesz też ręcznie ustawić wartość:
+```javascript
+// Ukryj Success Stories
+localStorage.setItem('showSuccessStories', 'false');
+location.reload(); // Odśwież stronę
+
+// Pokaż Success Stories
+localStorage.setItem('showSuccessStories', 'true');
+location.reload(); // Odśwież stronę
+```

--- a/ODPOWIEDZ_NA_PYTANIE.md
+++ b/ODPOWIEDZ_NA_PYTANIE.md
@@ -1,0 +1,197 @@
+# Odpowiedź: Czy trzeba coś wciskać po przełączeniu Success Stories?
+
+## Krótka odpowiedź: **NIE**
+
+**Nie musisz** wciskać żadnego przycisku "Publikuj online" ani niczego podobnego. 
+
+Przełącznik działa **automatycznie** i zapisuje się natychmiast do localStorage przeglądarki.
+
+---
+
+## JEDNAK: Musisz odświeżyć strony!
+
+### To jest prawdopodobnie Twój problem! ⚠️
+
+Gdy przełączasz przełącznik w CMS:
+1. ✅ Ustawienie **zapisuje się automatycznie** (nie musisz nic wciskać)
+2. ❌ **ALE** strony które już masz otwarte **NIE WIEDZĄ** o tej zmianie
+3. ✅ **MUSISZ ODŚWIEŻYĆ** strony aby zobaczyć efekt
+
+### Poprawna procedura:
+
+```
+1. Otwórz /landing/admin.html
+2. Wyłącz przełącznik "Success Stories Page"
+   → Pojawi się napis "Hidden" i komunikat o zapisaniu
+3. Przejdź do /landing/index.html (lub index-pl.html)
+4. ⚠️ NACIŚNIJ F5 (odśwież stronę!) ⚠️
+5. Teraz zakładka Success Stories powinna być ukryta
+```
+
+---
+
+## Dlaczego tak to działa?
+
+### Techniczne wyjaśnienie:
+
+1. **CMS zapisuje do localStorage**
+   - Kliknięcie przełącznika → `localStorage.setItem('showSuccessStories', 'false')`
+   - To dzieje się natychmiast, bez żadnych dodatkowych akcji
+
+2. **Każda strona czyta z localStorage przy ładowaniu**
+   - Przy otwieraniu strony → wykonuje się `updateSuccessStoriesVisibility()`
+   - Ta funkcja czyta wartość z localStorage
+   - I ukrywa/pokazuje linki Success Stories
+
+3. **Strony już załadowane nie reagują automatycznie**
+   - JavaScript nie ma mechanizmu "live update" między kartami
+   - Dlatego musisz odświeżyć stronę (F5)
+
+---
+
+## Jak przetestować czy działa?
+
+### Test 1: Konsola przeglądarki (najszybszy)
+
+1. Otwórz `/landing/index.html`
+2. Naciśnij **F12** → zakładka **Console**
+3. Wklej:
+```javascript
+localStorage.getItem('showSuccessStories')
+```
+4. Wynik:
+   - `"false"` = Success Stories powinny być ukryte
+   - `"true"` lub `null` = Success Stories powinny być widoczne
+
+### Test 2: Strona testowa
+
+Stworzyłem dla Ciebie stronę testową:
+
+```
+Otwórz: /workspace/test-success-stories-toggle.html
+```
+
+Ta strona:
+- ✅ Pokazuje obecny stan localStorage
+- ✅ Pozwala przełączać widoczność
+- ✅ Pokazuje które linki zostały znalezione i ukryte
+- ✅ Nie wymaga odświeżania (wszystko działa natychmiast)
+
+### Test 3: Pełna diagnostyka
+
+Jeśli nadal nie działa, sprawdź plik:
+```
+/workspace/DIAGNOSTYKA_SUCCESS_STORIES.md
+```
+
+Znajdziesz tam skrypt diagnostyczny do wklejenia w konsolę.
+
+---
+
+## Częste problemy i rozwiązania
+
+### Problem 1: "Wyłączyłem przełącznik ale nic się nie zmieniło"
+
+**Rozwiązanie:** Odśwież stronę (F5)
+
+### Problem 2: "Po odświeżeniu admin.html przełącznik wraca do 'Visible'"
+
+**Możliwe przyczyny:**
+- localStorage jest zablokowany w przeglądarce
+- Tryb prywatny/incognito (localStorage może być ograniczony)
+- Coś czyści localStorage
+
+**Test:**
+```javascript
+// W konsoli przeglądarki (F12)
+localStorage.setItem('test', '123');
+localStorage.getItem('test'); // Powinno zwrócić '123'
+```
+
+### Problem 3: "Na stronie polskiej nadal widać Success Stories"
+
+To też wymaga odświeżenia! Przełącznik działa zarówno dla EN jak i PL, ale:
+1. Wyłącz w `/landing/admin.html`
+2. **Odśwież** `/landing/index.html` (F5)
+3. **Odśwież** `/landing/index-pl.html` (F5)
+
+### Problem 4: "W stopce nadal widać Success Stories"
+
+To jest obsługiwane! Funkcja ukrywa:
+- Link w menu desktop
+- Link w menu mobile
+- **Element `<li>` w stopce** (cały element listy, nie tylko link)
+
+Jeśli to nie działa → uruchom diagnostykę.
+
+---
+
+## Wymuszenie ukrycia (obejście)
+
+Jeśli nic nie działa, możesz ręcznie wymusić ukrycie w konsoli:
+
+```javascript
+// Ustaw i odśwież
+localStorage.setItem('showSuccessStories', 'false');
+location.reload();
+```
+
+Lub pokaż z powrotem:
+```javascript
+localStorage.setItem('showSuccessStories', 'true');
+location.reload();
+```
+
+---
+
+## Podsumowanie
+
+| Pytanie | Odpowiedź |
+|---------|-----------|
+| Czy trzeba wciskać "Publikuj"? | ❌ NIE |
+| Czy zmiana zapisuje się automatycznie? | ✅ TAK |
+| Czy trzeba odświeżać strony? | ✅ TAK (F5) |
+| Czy działa dla stron PL i EN? | ✅ TAK (obie) |
+| Czy działa w stopce? | ✅ TAK |
+
+---
+
+## Pliki pomocnicze
+
+Stworzyłem dla Ciebie:
+
+1. **INSTRUKCJA_TESTOWANIA_SUCCESS_STORIES.md** - pełna instrukcja krok po kroku
+2. **DIAGNOSTYKA_SUCCESS_STORIES.md** - narzędzia diagnostyczne
+3. **test-success-stories-toggle.html** - interaktywna strona testowa
+
+---
+
+## Jeśli nadal nie działa...
+
+Uruchom pełną diagnostykę i sprawdź wyniki:
+
+```javascript
+// Wklej w konsolę (F12) na stronie index.html
+(function() {
+    console.log('=== TEST SUCCESS STORIES ===');
+    console.log('1. localStorage:', localStorage.getItem('showSuccessStories'));
+    
+    const links = document.querySelectorAll('a[href*="success-stories"]');
+    console.log('2. Znalezionych linków:', links.length);
+    
+    if (links.length > 0) {
+        console.log('3. Stan linków:');
+        links.forEach((link, i) => {
+            const parent = link.closest('li') || link;
+            console.log(`   #${i+1}: display =`, 
+                       parent.style.display || 'default',
+                       '|', link.textContent.trim());
+        });
+    }
+    
+    console.log('4. Funkcja istnieje:', 
+               typeof updateSuccessStoriesVisibility === 'function');
+})();
+```
+
+Wyślij mi wyniki jeśli problem będzie się utrzymywał.

--- a/test-success-stories-toggle.html
+++ b/test-success-stories-toggle.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test - Success Stories Toggle</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 p-8">
+    <div class="max-w-4xl mx-auto bg-white rounded-lg shadow-lg p-6">
+        <h1 class="text-3xl font-bold mb-6">🧪 Test ukrywania Success Stories</h1>
+        
+        <!-- Status Section -->
+        <div class="mb-6 p-4 bg-blue-50 rounded-lg">
+            <h2 class="text-xl font-semibold mb-3">Status localStorage:</h2>
+            <div class="space-y-2">
+                <p><strong>showSuccessStories:</strong> <span id="status-value" class="font-mono bg-gray-200 px-2 py-1 rounded"></span></p>
+                <p><strong>Success Stories powinny być:</strong> <span id="status-text" class="font-bold"></span></p>
+            </div>
+        </div>
+
+        <!-- Control Panel -->
+        <div class="mb-6 p-4 bg-green-50 rounded-lg">
+            <h2 class="text-xl font-semibold mb-3">Panel sterowania (test):</h2>
+            <div class="flex gap-4">
+                <button onclick="hideSuccessStories()" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">
+                    ❌ Ukryj Success Stories
+                </button>
+                <button onclick="showSuccessStories()" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">
+                    ✅ Pokaż Success Stories
+                </button>
+                <button onclick="location.reload()" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">
+                    🔄 Odśwież stronę
+                </button>
+            </div>
+        </div>
+
+        <!-- Test Links Section -->
+        <div class="mb-6 p-4 bg-yellow-50 rounded-lg">
+            <h2 class="text-xl font-semibold mb-3">Testowe linki Success Stories:</h2>
+            <p class="text-sm text-gray-600 mb-4">Poniższe linki powinny się ukrywać/pokazywać tak jak na prawdziwych stronach</p>
+            
+            <!-- Desktop Navigation (symulacja) -->
+            <div class="mb-4">
+                <h3 class="font-semibold mb-2">Menu Desktop:</h3>
+                <nav class="flex gap-4 p-3 bg-white border rounded">
+                    <a href="about.html" class="text-black hover:text-gray-600">About</a>
+                    <a href="success-stories.html" class="text-black hover:text-gray-600">Success Stories (EN)</a>
+                    <a href="success-stories-pl.html" class="text-black hover:text-gray-600">Historie sukcesu (PL)</a>
+                    <a href="blog.html" class="text-black hover:text-gray-600">Blog</a>
+                </nav>
+            </div>
+
+            <!-- Footer (symulacja) -->
+            <div class="mb-4">
+                <h3 class="font-semibold mb-2">Stopka (z elementami &lt;li&gt;):</h3>
+                <ul class="list-disc list-inside p-3 bg-white border rounded">
+                    <li><a href="about.html" class="hover:underline">About</a></li>
+                    <li><a href="success-stories.html" class="hover:underline">Success Stories (EN)</a></li>
+                    <li><a href="success-stories-pl.html" class="hover:underline">Historie sukcesu (PL)</a></li>
+                    <li><a href="blog.html" class="hover:underline">Blog</a></li>
+                </ul>
+            </div>
+        </div>
+
+        <!-- Found Links Debug -->
+        <div class="mb-6 p-4 bg-purple-50 rounded-lg">
+            <h2 class="text-xl font-semibold mb-3">🔍 Debug - znalezione linki:</h2>
+            <div id="debug-output" class="bg-white p-3 rounded border font-mono text-sm"></div>
+        </div>
+
+        <!-- Instructions -->
+        <div class="p-4 bg-gray-50 rounded-lg">
+            <h2 class="text-xl font-semibold mb-3">📋 Instrukcja:</h2>
+            <ol class="list-decimal list-inside space-y-2">
+                <li>Kliknij "Ukryj Success Stories" - linki powinny zniknąć NATYCHMIAST (bez odświeżania)</li>
+                <li>Kliknij "Pokaż Success Stories" - linki powinny się pojawić NATYCHMIAST</li>
+                <li>Kliknij "Odśwież stronę" - stan powinien być zachowany (linki nadal ukryte/widoczne)</li>
+                <li>Sprawdź "Debug - znalezione linki" aby zobaczyć ile linków zostało znalezionych</li>
+            </ol>
+            <p class="mt-4 text-sm text-gray-600">
+                <strong>Uwaga:</strong> Ta strona używa dokładnie tej samej funkcji <code>updateSuccessStoriesVisibility()</code> 
+                co prawdziwe strony w <code>/landing/</code>
+            </p>
+        </div>
+
+        <!-- Quick Links -->
+        <div class="mt-6 p-4 bg-indigo-50 rounded-lg">
+            <h2 class="text-xl font-semibold mb-3">🔗 Szybkie linki do testowania:</h2>
+            <div class="space-y-2">
+                <a href="landing/admin.html" class="block text-blue-600 hover:underline">→ Otwórz panel CMS (zmień ustawienie)</a>
+                <a href="landing/index.html" target="_blank" class="block text-blue-600 hover:underline">→ Strona angielska (index.html)</a>
+                <a href="landing/index-pl.html" target="_blank" class="block text-blue-600 hover:underline">→ Strona polska (index-pl.html)</a>
+            </div>
+        </div>
+    </div>
+
+    <!-- Load the same auth.js that real pages use -->
+    <script src="landing/auth.js"></script>
+
+    <script>
+        // Additional test functions
+        function hideSuccessStories() {
+            localStorage.setItem('showSuccessStories', 'false');
+            updateStatus();
+            updateSuccessStoriesVisibility();
+            updateDebug();
+        }
+
+        function showSuccessStories() {
+            localStorage.setItem('showSuccessStories', 'true');
+            updateStatus();
+            updateSuccessStoriesVisibility();
+            updateDebug();
+        }
+
+        function updateStatus() {
+            const value = localStorage.getItem('showSuccessStories');
+            const isVisible = value !== 'false';
+            
+            document.getElementById('status-value').textContent = value || '(nie ustawione - domyślnie true)';
+            document.getElementById('status-text').textContent = isVisible ? '✅ WIDOCZNE' : '❌ UKRYTE';
+            document.getElementById('status-text').className = isVisible ? 'font-bold text-green-600' : 'font-bold text-red-600';
+        }
+
+        function updateDebug() {
+            const allLinks = document.querySelectorAll('a[href*="success-stories"]');
+            const debugOutput = document.getElementById('debug-output');
+            
+            let html = `<p class="mb-2"><strong>Znaleziono ${allLinks.length} linków zawierających "success-stories":</strong></p>`;
+            html += '<ul class="list-disc list-inside space-y-1">';
+            
+            allLinks.forEach((link, index) => {
+                const parentLi = link.closest('li');
+                const elementToHide = parentLi || link;
+                const isHidden = elementToHide.style.display === 'none';
+                const status = isHidden ? '❌ UKRYTY' : '✅ WIDOCZNY';
+                
+                html += `<li>
+                    ${status} - "${link.textContent.trim()}" 
+                    (href: ${link.getAttribute('href')})
+                    ${parentLi ? '[w &lt;li&gt;]' : '[samodzielny]'}
+                </li>`;
+            });
+            
+            html += '</ul>';
+            debugOutput.innerHTML = html;
+        }
+
+        // Initialize on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            updateStatus();
+            updateDebug();
+            
+            // Show a message after updateNav runs
+            setTimeout(() => {
+                console.log('✅ Funkcja updateSuccessStoriesVisibility() została wykonana przez auth.js');
+                console.log('Wartość showSuccessStories:', localStorage.getItem('showSuccessStories'));
+            }, 100);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add documentation and a test page to clarify the behavior of the "Success Stories" visibility toggle.

This PR addresses the user's confusion regarding the immediate effect of toggling the "hide Success Stories" switch in the CMS. It explains that a page refresh is required for changes to take effect and provides diagnostic tools and a dedicated test page for troubleshooting.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3dd24e6-feaf-4ec3-8ee5-c053bc78c336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3dd24e6-feaf-4ec3-8ee5-c053bc78c336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

