### PR TITLE
Fix success stories hide button in cms

### DIFF
--- a/SUCCESS_STORIES_TOGGLE_NAPRAWIONY.md
+++ b/SUCCESS_STORIES_TOGGLE_NAPRAWIONY.md
@@ -1,0 +1,124 @@
+# Naprawa przycisku do ukrywania Success Stories w CMS
+
+## Problem
+Przycisk do ukrywania zakładki "Success Stories" w panelu administracyjnym CMS nie działał poprawnie. Po wyłączeniu przełącznika i kliknięciu "Publikuj Treści Online", ustawienie nie było zapisywane - po odświeżeniu strony (Ctrl+F5) przycisk wracał do stanu "Visible".
+
+## Przyczyna
+W pliku `/workspace/admin.html` znajdował się element HTML przełącznika (toggle), ale **brakował kodu JavaScript** odpowiedzialnego za:
+1. Zapisywanie stanu przełącznika do `localStorage`
+2. Wczytywanie stanu przy ładowaniu strony
+3. Aktualizowanie etykiety (Visible/Hidden lub Widoczne/Ukryte)
+
+Plik `/workspace/landing/admin.html` miał już pełną implementację, ale główny plik administracyjny nie.
+
+## Rozwiązanie
+Dodano brakujący kod JavaScript do pliku `/workspace/admin.html` (linie 2878-2921):
+
+```javascript
+// Navigation Settings - Success Stories Toggle
+const toggleSuccessStories = document.getElementById('toggle-success-stories');
+const toggleSuccessStoriesLabel = document.getElementById('toggle-success-stories-label');
+const navSettingsMsg = document.getElementById('nav-settings-save-msg');
+
+// Load initial state from localStorage
+function loadNavigationSettings() {
+    const isVisible = localStorage.getItem('showSuccessStories') !== 'false';
+    if (toggleSuccessStories) {
+        toggleSuccessStories.checked = isVisible;
+        updateToggleLabel(isVisible);
+    }
+}
+
+function updateToggleLabel(isVisible) {
+    if (toggleSuccessStoriesLabel) {
+        const lang = document.documentElement.lang || 'en';
+        if (lang === 'pl') {
+            toggleSuccessStoriesLabel.textContent = isVisible ? 'Widoczne' : 'Ukryte';
+        } else {
+            toggleSuccessStoriesLabel.textContent = isVisible ? 'Visible' : 'Hidden';
+        }
+    }
+}
+
+// Save state when toggle changes
+if (toggleSuccessStories) {
+    toggleSuccessStories.addEventListener('change', function() {
+        const isVisible = this.checked;
+        localStorage.setItem('showSuccessStories', isVisible ? 'true' : 'false');
+        updateToggleLabel(isVisible);
+        
+        if (navSettingsMsg) {
+            navSettingsMsg.classList.remove('hidden');
+            setTimeout(() => navSettingsMsg.classList.add('hidden'), 2000);
+        }
+    });
+}
+
+// Initialize navigation settings on page load
+loadNavigationSettings();
+```
+
+## Jak to działa teraz
+
+### 1. **Zapisywanie ustawienia**
+Gdy admin przełącza przycisk Success Stories:
+- Stan jest natychmiast zapisywany w `localStorage` jako `showSuccessStories: 'true'` lub `'false'`
+- Etykieta zmienia się na "Visible"/"Hidden" (EN) lub "Widoczne"/"Ukryte" (PL)
+- Pojawia się komunikat "Navigation settings saved automatically"
+
+### 2. **Publikowanie online**
+Gdy admin klika "📤 Publikuj Treści Online":
+- Skrypt `cms-sync.js` synchronizuje **wszystkie** dane z `localStorage` (w tym `showSuccessStories`) do serwera
+- Dane są zapisywane w pliku `cms-data.json` przez Netlify Function
+- Ustawienie staje się dostępne dla wszystkich użytkowników
+
+### 3. **Wczytywanie przy odświeżeniu**
+Gdy strona jest ponownie ładowana:
+- `cms-sync.js` automatycznie wczytuje dane z serwera do `localStorage`
+- Funkcja `loadNavigationSettings()` odczytuje wartość `showSuccessStories`
+- Przełącznik ustawia się w odpowiedniej pozycji (włączony/wyłączony)
+- Etykieta aktualizuje się odpowiednio
+
+### 4. **Ukrywanie linków na stronach**
+Na wszystkich stronach publicznych (index.html, about.html, itp.):
+- Skrypt `auth.js` zawiera funkcję `updateSuccessStoriesVisibility()`
+- Funkcja ta sprawdza wartość `localStorage.getItem('showSuccessStories')`
+- Wszystkie linki do `success-stories.html` są ukrywane/pokazywane (`display: none/''`)
+
+## Testowanie
+
+### Krok 1: Wyłącz Success Stories
+1. Otwórz panel CMS: `/admin.html`
+2. W sekcji "Navigation Settings" **wyłącz** przełącznik "Success Stories Page"
+3. Sprawdź, że etykieta zmienia się na "Hidden" / "Ukryte"
+4. Kliknij **"📤 Publikuj Treści Online"** (zielony przycisk w prawym dolnym rogu)
+5. Poczekaj na komunikat "✅ Treści opublikowane!"
+
+### Krok 2: Odśwież i sprawdź
+6. Naciśnij **Ctrl+F5** (twarde odświeżenie)
+7. **Przełącznik powinien pozostać WYŁĄCZONY** ✅
+8. Przejdź na stronę główną: `/index.html`
+9. Zakładka "Success Stories" **nie powinna być widoczna** w nawigacji ✅
+
+### Krok 3: Włącz ponownie
+10. Wróć do `/admin.html`
+11. **Włącz** przełącznik "Success Stories Page"
+12. Kliknij **"📤 Publikuj Treści Online"**
+13. Po odświeżeniu (Ctrl+F5) przełącznik powinien pozostać WŁĄCZONY ✅
+14. Zakładka "Success Stories" powinna być znowu widoczna na stronie ✅
+
+## Pliki zmodyfikowane
+- ✅ `/workspace/admin.html` - dodano obsługę JavaScript dla przełącznika
+
+## Pliki niezmienione (już działały poprawnie)
+- `/workspace/landing/admin.html` - już miało pełną implementację
+- `/workspace/cms-sync.js` - automatycznie synchronizuje wszystkie ustawienia
+- `/workspace/auth.js` - ukrywa/pokazuje linki na stronach publicznych
+
+## Podsumowanie
+Problem został **całkowicie naprawiony**. Teraz przełącznik Success Stories:
+- ✅ Zapisuje stan do localStorage
+- ✅ Synchronizuje ustawienie z serwerem przy kliknięciu "Publikuj Treści Online"
+- ✅ Zachowuje stan po odświeżeniu strony (Ctrl+F5)
+- ✅ Ukrywa/pokazuje linki Success Stories na wszystkich stronach
+- ✅ Działa zarówno w wersji polskiej jak i angielskiej

--- a/admin.html
+++ b/admin.html
@@ -2874,6 +2874,51 @@
                 }
             });
         }
+
+        // -------------------------------------------------------------------
+        // Navigation Settings - Success Stories Toggle
+        const toggleSuccessStories = document.getElementById('toggle-success-stories');
+        const toggleSuccessStoriesLabel = document.getElementById('toggle-success-stories-label');
+        const navSettingsMsg = document.getElementById('nav-settings-save-msg');
+
+        // Load initial state from localStorage
+        function loadNavigationSettings() {
+            const isVisible = localStorage.getItem('showSuccessStories') !== 'false';
+            if (toggleSuccessStories) {
+                toggleSuccessStories.checked = isVisible;
+                updateToggleLabel(isVisible);
+            }
+        }
+
+        function updateToggleLabel(isVisible) {
+            if (toggleSuccessStoriesLabel) {
+                // Support both EN and PL - check document language
+                const lang = document.documentElement.lang || 'en';
+                if (lang === 'pl') {
+                    toggleSuccessStoriesLabel.textContent = isVisible ? 'Widoczne' : 'Ukryte';
+                } else {
+                    toggleSuccessStoriesLabel.textContent = isVisible ? 'Visible' : 'Hidden';
+                }
+            }
+        }
+
+        // Save state when toggle changes
+        if (toggleSuccessStories) {
+            toggleSuccessStories.addEventListener('change', function() {
+                const isVisible = this.checked;
+                localStorage.setItem('showSuccessStories', isVisible ? 'true' : 'false');
+                updateToggleLabel(isVisible);
+                
+                // Show confirmation message
+                if (navSettingsMsg) {
+                    navSettingsMsg.classList.remove('hidden');
+                    setTimeout(() => navSettingsMsg.classList.add('hidden'), 2000);
+                }
+            });
+        }
+
+        // Initialize navigation settings on page load
+        loadNavigationSettings();
     });
     </script>
     <!-- Load CMS sync script for server persistence -->


### PR DESCRIPTION
Add missing JavaScript logic to the Success Stories visibility toggle in `admin.html` to correctly save and load its state.

The toggle's UI was present, but without the corresponding JavaScript, its state was not persisted in `localStorage` or synced to the server, leading to it reverting to "Visible" after a refresh. This fix aligns its functionality with `landing/admin.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9875fbc8-52ab-43f1-bb61-5b0a7b3c914a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9875fbc8-52ab-43f1-bb61-5b0a7b3c914a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

