### PR TITLE
Add polish translation for influencer login

### DIFF
--- a/landing/login-pl.html
+++ b/landing/login-pl.html
@@ -33,7 +33,8 @@
     </a>
     <div class="bg-white p-8 rounded-lg shadow-md w-full max-w-md">
         <h1 id="login-title" class="text-3xl font-bold mb-6 text-center">Influencer Login</h1>
-        <p id="login-subtitle" class="text-sm text-gray-600 mb-4 text-center">Enter the credentials provided in your acceptance email.</p>
+        <p id="login-subtitle" class="text-sm text-gray-600 mb-4 text-center" style="white-space: pre-line;">Wprowadź dane logowania z e-maila akceptacyjnego.
+Aby się zarejestrować, zapisz się na listę oczekujących, a wkrótce wyślemy Ci e-mail z danymi do logowania.</p>
         <!-- Language switcher inside login card -->
         <div class="flex justify-center items-center text-sm mb-4">
             <a href="login.html" class="text-black hover:text-gray-600 font-medium">EN</a>

--- a/login-pl.html
+++ b/login-pl.html
@@ -15,7 +15,8 @@
     </a>
     <div class="bg-white p-8 rounded-lg shadow-md w-full max-w-md">
         <h1 id="login-title" class="text-2xl font-bold mb-6 text-center">Influencer Login</h1>
-        <p id="login-subtitle" class="text-sm text-gray-600 mb-4 text-center">Enter the credentials provided in your acceptance email.</p>
+        <p id="login-subtitle" class="text-sm text-gray-600 mb-4 text-center" style="white-space: pre-line;">Wprowadź dane logowania z e-maila akceptacyjnego.
+Aby się zarejestrować, zapisz się na listę oczekujących, a wkrótce wyślemy Ci e-mail z danymi do logowania.</p>
         <!-- Language switcher inside login card -->
         <div class="flex justify-center items-center text-sm mb-4">
             <a href="login.html" class="text-black hover:text-gray-600 font-medium">EN</a>


### PR DESCRIPTION
Add Polish translation and `white-space: pre-line` style to the influencer login form to correctly display the multi-line text.

---
<a href="https://cursor.com/background-agent?bcId=bc-b62c7702-f501-4980-b2cd-962e50c761ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b62c7702-f501-4980-b2cd-962e50c761ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

