### PR TITLE
Add internal linking to blog posts

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -510,6 +510,16 @@
             <div class="mb-4">
                 <label for="blog-content" class="block text-sm font-medium text-gray-700 mb-1">Content</label>
                 <textarea id="blog-content" rows="6" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black"></textarea>
+                <div class="mt-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                    <p class="text-sm font-semibold text-blue-900 mb-1">💡 How to add links (Internal Linking):</p>
+                    <p class="text-xs text-blue-800 mb-2">Use markdown-style syntax: <code class="bg-blue-100 px-1 py-0.5 rounded">[link text](url)</code></p>
+                    <p class="text-xs text-blue-700"><strong>Examples:</strong></p>
+                    <ul class="text-xs text-blue-700 list-disc ml-4 space-y-1">
+                        <li>Internal link: <code class="bg-blue-100 px-1 py-0.5 rounded">[Read our guide](about.html)</code></li>
+                        <li>Another post: <code class="bg-blue-100 px-1 py-0.5 rounded">[See this article](post.html?index=0)</code></li>
+                        <li>External link: <code class="bg-blue-100 px-1 py-0.5 rounded">[Visit Google](https://google.com)</code></li>
+                    </ul>
+                </div>
             </div>
             <!-- SEO Meta Description -->
             <div class="mb-4">
@@ -566,6 +576,16 @@
             <div class="mb-4">
                 <label for="blog-content-pl" class="block text-sm font-medium text-gray-700 mb-1">Treść</label>
                 <textarea id="blog-content-pl" rows="6" class="w-full border border-gray-300 rounded-lg p-3 focus:outline-none focus:ring-2 focus:ring-black"></textarea>
+                <div class="mt-2 p-3 bg-blue-50 border border-blue-200 rounded-lg">
+                    <p class="text-sm font-semibold text-blue-900 mb-1">💡 Jak dodawać linki (Internal Linking):</p>
+                    <p class="text-xs text-blue-800 mb-2">Użyj składni markdown: <code class="bg-blue-100 px-1 py-0.5 rounded">[tekst linku](url)</code></p>
+                    <p class="text-xs text-blue-700"><strong>Przykłady:</strong></p>
+                    <ul class="text-xs text-blue-700 list-disc ml-4 space-y-1">
+                        <li>Link wewnętrzny: <code class="bg-blue-100 px-1 py-0.5 rounded">[Przeczytaj nasz przewodnik](about-pl.html)</code></li>
+                        <li>Inny post: <code class="bg-blue-100 px-1 py-0.5 rounded">[Zobacz ten artykuł](post-pl.html?index=0)</code></li>
+                        <li>Link zewnętrzny: <code class="bg-blue-100 px-1 py-0.5 rounded">[Odwiedź Google](https://google.com)</code></li>
+                    </ul>
+                </div>
             </div>
             <!-- SEO Meta Description (PL) -->
             <div class="mb-4">

--- a/landing/post-pl.html
+++ b/landing/post-pl.html
@@ -179,14 +179,51 @@
         title.className = 'text-4xl font-display font-bold text-black mb-4';
         title.textContent = post.title || 'Untitled';
         container.appendChild(title);
-        // Full content
+        // Full content with link parsing
         const paragraphs = (post.content || '').split(/\n+/).filter(l => l.trim() !== '');
         paragraphs.forEach(function(p) {
             const para = document.createElement('p');
             para.className = 'text-lg text-gray-700 mb-4';
-            para.textContent = p;
+            // Parse markdown-style links: [text](url)
+            para.innerHTML = parseLinksInText(p);
             container.appendChild(para);
         });
+        
+        // Function to parse markdown-style links and convert them to HTML
+        function parseLinksInText(text) {
+            // Escape HTML first to prevent XSS
+            const escapeHtml = (str) => {
+                const div = document.createElement('div');
+                div.textContent = str;
+                return div.innerHTML;
+            };
+            
+            // Replace [text](url) with <a> tags
+            // The regex matches [link text](url) format
+            return escapeHtml(text).replace(/\[([^\]]+)\]\(([^)]+)\)/g, function(match, linkText, url) {
+                // Unescape the link text and URL for proper display
+                const unescapeHtml = (str) => {
+                    const textarea = document.createElement('textarea');
+                    textarea.innerHTML = str;
+                    return textarea.value;
+                };
+                const displayText = unescapeHtml(linkText);
+                const linkUrl = unescapeHtml(url);
+                
+                // Determine if it's an internal or external link
+                const isInternal = linkUrl.startsWith('/') || linkUrl.startsWith('./') || 
+                                   linkUrl.startsWith('../') || linkUrl.startsWith('index') || 
+                                   linkUrl.startsWith('about') || linkUrl.startsWith('blog') ||
+                                   linkUrl.startsWith('how-it-works') || linkUrl.startsWith('success-stories') ||
+                                   linkUrl.startsWith('post-pl.html') || linkUrl.startsWith('login');
+                
+                if (isInternal) {
+                    return '<a href="' + escapeHtml(linkUrl) + '" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                } else {
+                    return '<a href="' + escapeHtml(linkUrl) + '" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                }
+            });
+        }
     });
     </script>
     <script>

--- a/landing/post.html
+++ b/landing/post.html
@@ -179,14 +179,51 @@
         title.className = 'text-4xl font-display font-bold text-black mb-4';
         title.textContent = post.title || 'Untitled';
         container.appendChild(title);
-        // Full content
+        // Full content with link parsing
         const paragraphs = (post.content || '').split(/\n+/).filter(l => l.trim() !== '');
         paragraphs.forEach(function(p) {
             const para = document.createElement('p');
             para.className = 'text-lg text-gray-700 mb-4';
-            para.textContent = p;
+            // Parse markdown-style links: [text](url)
+            para.innerHTML = parseLinksInText(p);
             container.appendChild(para);
         });
+        
+        // Function to parse markdown-style links and convert them to HTML
+        function parseLinksInText(text) {
+            // Escape HTML first to prevent XSS
+            const escapeHtml = (str) => {
+                const div = document.createElement('div');
+                div.textContent = str;
+                return div.innerHTML;
+            };
+            
+            // Replace [text](url) with <a> tags
+            // The regex matches [link text](url) format
+            return escapeHtml(text).replace(/\[([^\]]+)\]\(([^)]+)\)/g, function(match, linkText, url) {
+                // Unescape the link text and URL for proper display
+                const unescapeHtml = (str) => {
+                    const textarea = document.createElement('textarea');
+                    textarea.innerHTML = str;
+                    return textarea.value;
+                };
+                const displayText = unescapeHtml(linkText);
+                const linkUrl = unescapeHtml(url);
+                
+                // Determine if it's an internal or external link
+                const isInternal = linkUrl.startsWith('/') || linkUrl.startsWith('./') || 
+                                   linkUrl.startsWith('../') || linkUrl.startsWith('index') || 
+                                   linkUrl.startsWith('about') || linkUrl.startsWith('blog') ||
+                                   linkUrl.startsWith('how-it-works') || linkUrl.startsWith('success-stories') ||
+                                   linkUrl.startsWith('post.html') || linkUrl.startsWith('login');
+                
+                if (isInternal) {
+                    return '<a href="' + escapeHtml(linkUrl) + '" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                } else {
+                    return '<a href="' + escapeHtml(linkUrl) + '" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                }
+            });
+        }
     });
     </script>
     <script>

--- a/post-pl.html
+++ b/post-pl.html
@@ -283,14 +283,51 @@
             snippetBox.appendChild(snippetText);
             container.appendChild(snippetBox);
         }
-        // Full content
+        // Full content with link parsing
         const paragraphs = (post.content || '').split(/\n+/).filter(l => l.trim() !== '');
         paragraphs.forEach(function(p) {
             const para = document.createElement('p');
             para.className = 'text-lg text-gray-700 mb-4';
-            para.textContent = p;
+            // Parse markdown-style links: [text](url)
+            para.innerHTML = parseLinksInText(p);
             container.appendChild(para);
         });
+        
+        // Function to parse markdown-style links and convert them to HTML
+        function parseLinksInText(text) {
+            // Escape HTML first to prevent XSS
+            const escapeHtml = (str) => {
+                const div = document.createElement('div');
+                div.textContent = str;
+                return div.innerHTML;
+            };
+            
+            // Replace [text](url) with <a> tags
+            // The regex matches [link text](url) format
+            return escapeHtml(text).replace(/\[([^\]]+)\]\(([^)]+)\)/g, function(match, linkText, url) {
+                // Unescape the link text and URL for proper display
+                const unescapeHtml = (str) => {
+                    const textarea = document.createElement('textarea');
+                    textarea.innerHTML = str;
+                    return textarea.value;
+                };
+                const displayText = unescapeHtml(linkText);
+                const linkUrl = unescapeHtml(url);
+                
+                // Determine if it's an internal or external link
+                const isInternal = linkUrl.startsWith('/') || linkUrl.startsWith('./') || 
+                                   linkUrl.startsWith('../') || linkUrl.startsWith('index') || 
+                                   linkUrl.startsWith('about') || linkUrl.startsWith('blog') ||
+                                   linkUrl.startsWith('how-it-works') || linkUrl.startsWith('success-stories') ||
+                                   linkUrl.startsWith('post-pl.html') || linkUrl.startsWith('login');
+                
+                if (isInternal) {
+                    return '<a href="' + escapeHtml(linkUrl) + '" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                } else {
+                    return '<a href="' + escapeHtml(linkUrl) + '" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                }
+            });
+        }
     });
     </script>
     <script>

--- a/post.html
+++ b/post.html
@@ -281,14 +281,51 @@
             snippetBox.appendChild(snippetText);
             container.appendChild(snippetBox);
         }
-        // Full content
+        // Full content with link parsing
         const paragraphs = (post.content || '').split(/\n+/).filter(l => l.trim() !== '');
         paragraphs.forEach(function(p) {
             const para = document.createElement('p');
             para.className = 'text-lg text-gray-700 mb-4';
-            para.textContent = p;
+            // Parse markdown-style links: [text](url)
+            para.innerHTML = parseLinksInText(p);
             container.appendChild(para);
         });
+        
+        // Function to parse markdown-style links and convert them to HTML
+        function parseLinksInText(text) {
+            // Escape HTML first to prevent XSS
+            const escapeHtml = (str) => {
+                const div = document.createElement('div');
+                div.textContent = str;
+                return div.innerHTML;
+            };
+            
+            // Replace [text](url) with <a> tags
+            // The regex matches [link text](url) format
+            return escapeHtml(text).replace(/\[([^\]]+)\]\(([^)]+)\)/g, function(match, linkText, url) {
+                // Unescape the link text and URL for proper display
+                const unescapeHtml = (str) => {
+                    const textarea = document.createElement('textarea');
+                    textarea.innerHTML = str;
+                    return textarea.value;
+                };
+                const displayText = unescapeHtml(linkText);
+                const linkUrl = unescapeHtml(url);
+                
+                // Determine if it's an internal or external link
+                const isInternal = linkUrl.startsWith('/') || linkUrl.startsWith('./') || 
+                                   linkUrl.startsWith('../') || linkUrl.startsWith('index') || 
+                                   linkUrl.startsWith('about') || linkUrl.startsWith('blog') ||
+                                   linkUrl.startsWith('how-it-works') || linkUrl.startsWith('success-stories') ||
+                                   linkUrl.startsWith('post.html') || linkUrl.startsWith('login');
+                
+                if (isInternal) {
+                    return '<a href="' + escapeHtml(linkUrl) + '" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                } else {
+                    return '<a href="' + escapeHtml(linkUrl) + '" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-800 underline font-medium">' + escapeHtml(displayText) + '</a>';
+                }
+            });
+        }
     });
     </script>
     <script>


### PR DESCRIPTION
Add internal linking functionality to blog posts in both PL and EN versions.

This PR enables users to add markdown-style links (`[link text](url)`) within blog post content, supporting both internal and external links with appropriate opening behavior and XSS protection. Instructions for usage have been added to the admin panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-3cdf3def-27fb-4285-9fbf-f4b8286f1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cdf3def-27fb-4285-9fbf-f4b8286f1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

