### PR TITLE
Reduce blog tile spacing

### DIFF
--- a/blog-pl.html
+++ b/blog-pl.html
@@ -110,7 +110,7 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>
@@ -120,7 +120,7 @@
     </section>
 
     <!-- Blog Posts Grid -->
-    <section class="py-16 bg-white">
+    <section class="py-8 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div id="blog-posts-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div>
             <p id="no-posts-msg" class="text-gray-600 text-center mt-8 hidden">No blog posts available yet.</p>

--- a/blog.html
+++ b/blog.html
@@ -109,7 +109,7 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>
@@ -119,7 +119,7 @@
     </section>
 
     <!-- Blog Posts Grid -->
-    <section class="py-16 bg-white">
+    <section class="py-8 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div id="blog-posts-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div>
             <p id="no-posts-msg" class="text-gray-600 text-center mt-8 hidden">No blog posts available yet.</p>


### PR DESCRIPTION
Halve the vertical spacing on blog pages to reduce the gap between the menu bar and blog tiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f1a433d-6786-4fe9-ba94-cc76ad6c8280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f1a433d-6786-4fe9-ba94-cc76ad6c8280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

