### PR TITLE
Align blog post tiles with image

### DIFF
--- a/blog-pl.html
+++ b/blog-pl.html
@@ -120,7 +120,7 @@
     </section>
 
     <!-- Blog Posts Grid -->
-    <section class="py-16 bg-white">
+    <section class="pt-0 pb-16 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div id="blog-posts-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div>
             <p id="no-posts-msg" class="text-gray-600 text-center mt-8 hidden">No blog posts available yet.</p>

--- a/blog.html
+++ b/blog.html
@@ -119,7 +119,7 @@
     </section>
 
     <!-- Blog Posts Grid -->
-    <section class="py-16 bg-white">
+    <section class="pt-0 pb-16 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div id="blog-posts-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div>
             <p id="no-posts-msg" class="text-gray-600 text-center mt-8 hidden">No blog posts available yet.</p>


### PR DESCRIPTION
Remove top padding from blog posts grid to align blog tiles with blog post images.

---
<a href="https://cursor.com/background-agent?bcId=bc-82f43c21-de72-43a7-a511-2835206f1672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-82f43c21-de72-43a7-a511-2835206f1672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

