### PR TITLE
Adjust blog tile spacing for menu

### DIFF
--- a/blog-pl.html
+++ b/blog-pl.html
@@ -110,7 +110,7 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>

--- a/blog.html
+++ b/blog.html
@@ -109,7 +109,7 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>

--- a/landing/blog-pl.html
+++ b/landing/blog-pl.html
@@ -87,7 +87,7 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>

--- a/landing/blog.html
+++ b/landing/blog.html
@@ -87,7 +87,7 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>


### PR DESCRIPTION
Reduce the spacing in blog hero sections by half to decrease the distance between blog tiles and the top menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f0afc4b-9d29-4036-a331-3b968ff53f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f0afc4b-9d29-4036-a331-3b968ff53f02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

