### PR TITLE
Debug mobile hamburger calculator link issue

### DIFF
--- a/blog-pl.html
+++ b/blog-pl.html
@@ -63,7 +63,7 @@
                     <a href="how-it-works-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Jak&nbsp;to&nbsp;działa</a>
                     <a href="success-stories-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Historie&nbsp;sukcesu</a>
                     <a href="blog-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Blog</a>
-                    <a href="index.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
+                    <a href="index-pl.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
                     <a href="your-documents-pl.html" id="nav-documents" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
                     <a href="admin.html" id="nav-admin" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Admin</a>
                     <a href="login-pl.html" id="nav-login" class="text-black hover:text-gray-600 transition-colors font-medium">Zaloguj&nbsp;się</a>
@@ -94,7 +94,7 @@
             <a href="how-it-works-pl.html" class="block text-black font-medium">Jak&nbsp;to&nbsp;działa</a>
             <a href="success-stories-pl.html" class="block text-black font-medium">Historie&nbsp;sukcesu</a>
             <a href="blog-pl.html" class="block text-black font-medium">Blog</a>
-            <a href="index.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
+            <a href="index-pl.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
             <a href="your-documents-pl.html" id="nav-documents-mobile" class="block text-black font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
             <a href="admin.html" id="nav-admin-mobile" class="block text-black font-medium" style="display: none;">Admin</a>
             <a href="login-pl.html" id="nav-login-mobile" class="block text-black font-medium">Zaloguj&nbsp;się</a>

--- a/how-it-works-pl.html
+++ b/how-it-works-pl.html
@@ -83,7 +83,7 @@
                     <a href="how-it-works-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Jak&nbsp;to&nbsp;działa</a>
                     <a href="success-stories-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Historie&nbsp;sukcesu</a>
                     <a href="blog-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Blog</a>
-                    <a href="index.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
+                    <a href="index-pl.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
                     <a href="your-documents-pl.html" id="nav-documents" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
                     <!-- Admin dashboard link (hidden when not logged in as admin) -->
                     <a href="admin.html" id="nav-admin" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Admin</a>
@@ -114,7 +114,7 @@
         <a href="how-it-works-pl.html" class="block text-black font-medium">Jak&nbsp;to&nbsp;działa</a>
         <a href="success-stories-pl.html" class="block text-black font-medium">Historie&nbsp;sukcesu</a>
         <a href="blog-pl.html" class="block text-black font-medium">Blog</a>
-        <a href="index.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
+        <a href="index-pl.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
         <a href="your-documents-pl.html" id="nav-documents-mobile" class="block text-black font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
         <a href="admin.html" id="nav-admin-mobile" class="block text-black font-medium" style="display: none;">Admin</a>
         <a href="login-pl.html" id="nav-login-mobile" class="block text-black font-medium">Zaloguj&nbsp;się</a>

--- a/index-fashion-pl.html
+++ b/index-fashion-pl.html
@@ -221,7 +221,7 @@
                     <a href="success-stories-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Historie&nbsp;sukcesu</a>
                     <a href="blog-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Blog</a>
                     <!-- Updated to point to the calculator on the English index page because calculator is only available there -->
-                    <a href="index.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
+                    <a href="index-pl.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
                     <a href="your-documents-pl.html" id="nav-documents" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
                     <!-- Hidden admin dashboard link.  Visible only for admin sessions -->
                     <a href="admin.html" id="nav-admin" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Admin</a>
@@ -251,7 +251,7 @@
         <a href="how-it-works-pl.html" class="block text-black font-medium">Jak&nbsp;to&nbsp;działa</a>
         <a href="success-stories-pl.html" class="block text-black font-medium">Historie&nbsp;sukcesu</a>
         <a href="blog-pl.html" class="block text-black font-medium">Blog</a>
-        <a href="index.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
+        <a href="index-pl.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
         <a href="your-documents-pl.html" id="nav-documents-mobile" class="block text-black font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
         <a href="admin.html" id="nav-admin-mobile" class="block text-black font-medium" style="display: none;">Admin</a>
         <a href="login-pl.html" id="nav-login-mobile" class="block text-black font-medium">Zaloguj&nbsp;się</a>

--- a/post-pl.html
+++ b/post-pl.html
@@ -93,7 +93,7 @@
                     <a href="how-it-works-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Jak&nbsp;to&nbsp;działa</a>
                     <a href="success-stories-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Historie&nbsp;sukcesu</a>
                     <a href="blog-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Blog</a>
-                    <a href="index.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
+                    <a href="index-pl.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
                     <a href="your-documents-pl.html" id="nav-documents" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
                     <a href="admin.html" id="nav-admin" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Admin</a>
                     <a href="login-pl.html" id="nav-login" class="text-black hover:text-gray-600 transition-colors font-medium">Zaloguj&nbsp;się</a>
@@ -124,7 +124,7 @@
             <a href="how-it-works-pl.html" class="block text-black font-medium">Jak&nbsp;to&nbsp;działa</a>
             <a href="success-stories-pl.html" class="block text-black font-medium">Historie&nbsp;sukcesu</a>
             <a href="blog-pl.html" class="block text-black font-medium">Blog</a>
-            <a href="index.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
+            <a href="index-pl.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
             <a href="your-documents-pl.html" id="nav-documents-mobile" class="block text-black font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
             <a href="admin.html" id="nav-admin-mobile" class="block text-black font-medium" style="display: none;">Admin</a>
             <a href="login-pl.html" id="nav-login-mobile" class="block text-black font-medium">Zaloguj&nbsp;się</a>

--- a/success-stories-pl.html
+++ b/success-stories-pl.html
@@ -75,7 +75,7 @@
                     <a href="how-it-works-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Jak&nbsp;to&nbsp;działa</a>
                     <a href="success-stories-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Historie&nbsp;sukcesu</a>
                     <a href="blog-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Blog</a>
-                    <a href="index.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
+                    <a href="index-pl.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
                     <a href="your-documents-pl.html" id="nav-documents" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
                     <!-- Hidden admin link will appear when admin is logged in -->
                     <a href="admin.html" id="nav-admin" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Admin</a>
@@ -107,7 +107,7 @@
             <a href="how-it-works-pl.html" class="block text-black font-medium">Jak&nbsp;to&nbsp;działa</a>
             <a href="success-stories-pl.html" class="block text-black font-medium">Historie&nbsp;sukcesu</a>
             <a href="blog-pl.html" class="block text-black font-medium">Blog</a>
-            <a href="index.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
+            <a href="index-pl.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
             <a href="your-documents-pl.html" id="nav-documents-mobile" class="block text-black font-medium" style="display: none;">Twoje&nbsp;dokumenty</a>
             <a href="admin.html" id="nav-admin-mobile" class="block text-black font-medium" style="display: none;">Admin</a>
             <a href="login-pl.html" id="nav-login-mobile" class="block text-black font-medium">Zaloguj&nbsp;się</a>

--- a/your-documents-pl.html
+++ b/your-documents-pl.html
@@ -24,7 +24,7 @@
                     <a href="how-it-works-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Jak&nbsp;to&nbsp;działa</a>
                     <a href="success-stories-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Historie&nbsp;sukcesu</a>
                     <a href="blog-pl.html" class="text-black hover:text-gray-600 transition-colors font-medium">Blog</a>
-                    <a href="index.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
+                    <a href="index-pl.html#calculator-section" id="nav-calculator" class="text-black hover:text-gray-600 transition-colors font-medium">Kalkulator</a>
                     <a href="your-documents-pl.html" id="nav-documents" class="text-black hover:text-gray-600 transition-colors font-medium">Twoje&nbsp;dokumenty</a>
                     <a href="admin.html" id="nav-admin" class="text-black hover:text-gray-600 transition-colors font-medium" style="display: none;">Admin</a>
                     <a href="login-pl.html" id="nav-login" class="text-black hover:text-gray-600 transition-colors font-medium">Zaloguj&nbsp;się</a>
@@ -54,7 +54,7 @@
             <a href="how-it-works-pl.html" class="block text-black font-medium">Jak&nbsp;to&nbsp;działa</a>
             <a href="success-stories-pl.html" class="block text-black font-medium">Historie&nbsp;sukcesu</a>
             <a href="blog-pl.html" class="block text-black font-medium">Blog</a>
-            <a href="index.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
+            <a href="index-pl.html#calculator-section" id="nav-calculator-mobile" class="block text-black font-medium">Kalkulator</a>
             <a href="your-documents-pl.html" id="nav-documents-mobile" class="block text-black font-medium">Twoje&nbsp;dokumenty</a>
             <a href="admin.html" id="nav-admin-mobile" class="block text-black font-medium" style="display: none;">Admin</a>
             <a href="login-pl.html" id="nav-login-mobile" class="block text-black font-medium">Zaloguj&nbsp;się</a>


### PR DESCRIPTION
Corrected calculator links on Polish subpages to point to the Polish homepage, fixing an issue where they previously redirected to the English version.

The calculator links in both desktop and mobile navigation on several Polish subpages (e.g., `how-it-works-pl.html`) were incorrectly pointing to `index.html#calculator-section` instead of `index-pl.html#calculator-section`. This caused the calculator link to not function as expected for Polish users, redirecting them to the English version of the homepage.

---
<a href="https://cursor.com/background-agent?bcId=bc-6591da57-080f-4cc1-8bc9-98e3981483e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6591da57-080f-4cc1-8bc9-98e3981483e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

