### PR TITLE
Fix mobile calculator link and document message

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -309,10 +309,34 @@ function attachNavHandlers() {
   }
 }
 
+// Handle hash navigation after page load. If the URL contains a hash (e.g.,
+// #calculator-section), ensure the target element is visible and scroll to it.
+// This fixes the issue where navigating from a subpage to index.html#calculator-section
+// wouldn't scroll properly because the calculator section was initially hidden.
+function handleHashNavigation() {
+  const hash = window.location.hash;
+  if (hash) {
+    // Remove the '#' to get the element ID
+    const targetId = hash.substring(1);
+    const target = document.getElementById(targetId);
+    
+    if (target) {
+      // Ensure the target is visible (remove 'hidden' class if present)
+      target.classList.remove('hidden');
+      
+      // Scroll to the target after a short delay to ensure rendering is complete
+      setTimeout(() => {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 100);
+    }
+  }
+}
+
 // Run on every page load to adjust navigation and calculator state.
 document.addEventListener('DOMContentLoaded', function () {
   updateNav();
   attachNavHandlers();
   setupMobileMenu();
   loadFooter();
+  handleHashNavigation();
 });

--- a/landing/your-documents-pl.html
+++ b/landing/your-documents-pl.html
@@ -102,10 +102,13 @@
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
+        let hasDocuments = false;
+        
         if (stored) {
             try {
                 const docs = JSON.parse(stored);
                 if (Array.isArray(docs) && docs.length > 0) {
+                    hasDocuments = true;
                     // Clear placeholder
                     listElem.innerHTML = '';
                     docs.forEach(function(doc, index) {
@@ -120,7 +123,7 @@
                         // Show delete button only for admin users
                         if (typeof isAdmin === 'function' && isAdmin()) {
                             const btn = document.createElement('button');
-                            btn.textContent = 'Delete';
+                            btn.textContent = 'Usuń';
                             btn.className = 'text-red-600 hover:underline ml-4 text-sm';
                             btn.addEventListener('click', function() {
                                 docs.splice(index, 1);
@@ -135,6 +138,11 @@
             } catch (err) {
                 console.error('Failed to parse documents from localStorage', err);
             }
+        }
+        
+        // If no documents, ensure the "no documents" message is displayed
+        if (!hasDocuments) {
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Brak dokumentów. Sprawdź ponownie później.</li>';
         }
     });
     // After loading documents, override heading and message with Polish translations

--- a/landing/your-documents.html
+++ b/landing/your-documents.html
@@ -88,10 +88,13 @@
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
+        let hasDocuments = false;
+        
         if (stored) {
             try {
                 const docs = JSON.parse(stored);
                 if (Array.isArray(docs) && docs.length > 0) {
+                    hasDocuments = true;
                     // Clear placeholder
                     listElem.innerHTML = '';
                     docs.forEach(function(doc, index) {
@@ -121,6 +124,11 @@
             } catch (err) {
                 console.error('Failed to parse documents from localStorage', err);
             }
+        }
+        
+        // If no documents, ensure the "no documents" message is displayed
+        if (!hasDocuments) {
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">No documents available yet. Check back later.</li>';
         }
     });
     </script>

--- a/your-documents-pl.html
+++ b/your-documents-pl.html
@@ -104,10 +104,13 @@
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
+        let hasDocuments = false;
+        
         if (stored) {
             try {
                 const docs = JSON.parse(stored);
                 if (Array.isArray(docs) && docs.length > 0) {
+                    hasDocuments = true;
                     // Clear placeholder
                     listElem.innerHTML = '';
                     docs.forEach(function(doc, index) {
@@ -137,6 +140,11 @@
             } catch (err) {
                 console.error('Failed to parse documents from localStorage', err);
             }
+        }
+        
+        // If no documents, ensure the "no documents" message is displayed
+        if (!hasDocuments) {
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Brak dokumentów. Sprawdź ponownie później.</li>';
         }
     });
     </script>

--- a/your-documents.html
+++ b/your-documents.html
@@ -104,10 +104,13 @@
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
+        let hasDocuments = false;
+        
         if (stored) {
             try {
                 const docs = JSON.parse(stored);
                 if (Array.isArray(docs) && docs.length > 0) {
+                    hasDocuments = true;
                     // Clear placeholder
                     listElem.innerHTML = '';
                     docs.forEach(function(doc, index) {
@@ -137,6 +140,11 @@
             } catch (err) {
                 console.error('Failed to parse documents from localStorage', err);
             }
+        }
+        
+        // If no documents, ensure the "no documents" message is displayed
+        if (!hasDocuments) {
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">No documents available yet. Check back later.</li>';
         }
     });
     </script>


### PR DESCRIPTION
Fix calculator link navigation from subpages and correct "No documents available" message logic.

The calculator link from subpages was not scrolling to the target section on `index.html` because the section was initially hidden. The "No documents available" message was not correctly displayed or hidden based on the presence of documents.

---
<a href="https://cursor.com/background-agent?bcId=bc-e7f57a68-2396-4fac-b074-528b7f82aa18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e7f57a68-2396-4fac-b074-528b7f82aa18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

