### PR TITLE
Fix influencer calculator link and document text

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -94,32 +94,16 @@ function updateNav() {
         }
         // Allow calculator link to anchor to the calculator section. Preserve the
         // original target (index.html#calculator-section or index-pl.html#calculator-section)
+        // Determine the correct index page based on current page language
+        const currentPage = window.location.pathname;
+        const isPolish = currentPage.includes('-pl.html');
+        const targetIndex = isPolish ? 'index-pl.html#calculator-section' : 'index.html#calculator-section';
+        
         if (calcLink) {
-            // store original href on first run
-            if (!calcLink.dataset.original) {
-                calcLink.dataset.original = calcLink.getAttribute('href');
-            }
-            const original = calcLink.dataset.original;
-            if (original && original.includes('index-pl.html')) {
-                calcLink.setAttribute('href', 'index-pl.html#calculator-section');
-            } else if (original && original.includes('index.html')) {
-                calcLink.setAttribute('href', 'index.html#calculator-section');
-            } else {
-                calcLink.setAttribute('href', '#calculator-section');
-            }
+            calcLink.setAttribute('href', targetIndex);
         }
         if (calcLinkMobile) {
-            if (!calcLinkMobile.dataset.original) {
-                calcLinkMobile.dataset.original = calcLinkMobile.getAttribute('href');
-            }
-            const original = calcLinkMobile.dataset.original;
-            if (original && original.includes('index-pl.html')) {
-                calcLinkMobile.setAttribute('href', 'index-pl.html#calculator-section');
-            } else if (original && original.includes('index.html')) {
-                calcLinkMobile.setAttribute('href', 'index.html#calculator-section');
-            } else {
-                calcLinkMobile.setAttribute('href', '#calculator-section');
-            }
+            calcLinkMobile.setAttribute('href', targetIndex);
         }
         // reveal calculator section if present
         if (calcSection) calcSection.classList.remove('hidden');

--- a/landing/auth.js
+++ b/landing/auth.js
@@ -86,30 +86,13 @@ function updateNav() {
         if (adminLinkMobile) {
           adminLinkMobile.style.display = isAdmin() ? '' : 'none';
         }
-        // Allow calculator link to anchor to the calculator section. Preserve the
-        // original target (index.html#calculator-section or #calculator-section)
+        // Always link to index.html#calculator-section when logged in
+        // (landing folder only has English version)
         if (calcLink) {
-            // store original href on first run
-            if (!calcLink.dataset.original) {
-                calcLink.dataset.original = calcLink.getAttribute('href');
-            }
-            const original = calcLink.dataset.original;
-            if (original && original.includes('index.html')) {
-                calcLink.setAttribute('href', 'index.html#calculator-section');
-            } else {
-                calcLink.setAttribute('href', '#calculator-section');
-            }
+            calcLink.setAttribute('href', 'index.html#calculator-section');
         }
         if (calcLinkMobile) {
-            if (!calcLinkMobile.dataset.original) {
-                calcLinkMobile.dataset.original = calcLinkMobile.getAttribute('href');
-            }
-            const original = calcLinkMobile.dataset.original;
-            if (original && original.includes('index.html')) {
-                calcLinkMobile.setAttribute('href', 'index.html#calculator-section');
-            } else {
-                calcLinkMobile.setAttribute('href', '#calculator-section');
-            }
+            calcLinkMobile.setAttribute('href', 'index.html#calculator-section');
         }
         // reveal calculator section if present
         if (calcSection) calcSection.classList.remove('hidden');

--- a/landing/your-documents-pl.html
+++ b/landing/your-documents-pl.html
@@ -99,6 +99,7 @@
             window.location.href = 'login.html';
             return;
         }
+        const msgEl = document.getElementById('documents-message');
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
@@ -140,21 +141,26 @@
             }
         }
         
-        // If no documents, ensure the "no documents" message is displayed
+        // Update message based on whether documents exist
         if (!hasDocuments) {
-            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Brak dokumentów. Sprawdź ponownie później.</li>';
+            if (msgEl) msgEl.textContent = 'Brak dokumentów do wyświetlenia.';
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Sprawdź ponownie później.</li>';
+        } else {
+            if (msgEl) msgEl.textContent = 'Znajdziesz tutaj wszelkie dokumenty udostępnione Ci przez nas, takie jak umowy, broszury i prezentacje.';
         }
-    });
-    // After loading documents, override heading and message with Polish translations
-    document.addEventListener('DOMContentLoaded', function() {
+        
+        // Load CMS translations for title (message is already set based on hasDocuments)
         function t(key, fallback) {
             const val = localStorage.getItem(key);
             return val && val !== '' ? val : fallback;
         }
         const titleEl = document.getElementById('documents-title');
         if (titleEl) titleEl.textContent = t('plDocumentsTitle','Twoje dokumenty');
-        const msgEl = document.getElementById('documents-message');
-        if (msgEl) msgEl.textContent = t('plDocumentsMessage','Brak dokumentów do wyświetlenia.');
+        
+        // Only override message with CMS value if no documents (it was already set above)
+        if (!hasDocuments && msgEl) {
+            msgEl.textContent = t('plDocumentsMessage', 'Brak dokumentów do wyświetlenia.');
+        }
     });
     </script>
 

--- a/landing/your-documents.html
+++ b/landing/your-documents.html
@@ -85,6 +85,7 @@
             window.location.href = 'login.html';
             return;
         }
+        const msgEl = document.getElementById('documents-message');
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
@@ -126,9 +127,12 @@
             }
         }
         
-        // If no documents, ensure the "no documents" message is displayed
+        // Update message based on whether documents exist
         if (!hasDocuments) {
-            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">No documents available yet. Check back later.</li>';
+            if (msgEl) msgEl.textContent = 'No documents available yet.';
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Check back later for updates.</li>';
+        } else {
+            if (msgEl) msgEl.textContent = 'Below you\'ll find any documents we\'ve shared with you, such as agreements, brochures and presentations.';
         }
     });
     </script>

--- a/your-documents-pl.html
+++ b/your-documents-pl.html
@@ -99,8 +99,6 @@
         if (titleEl) titleEl.textContent = t('plDocumentsTitle', 'Twoje dokumenty');
         
         const msgEl = document.getElementById('documents-message');
-        if (msgEl) msgEl.textContent = t('plDocumentsMessage', 'Znajdziesz tutaj wszelkie dokumenty udostępnione Ci przez nas, takie jak umowy, broszury i prezentacje. Jeśli nic się nie pojawia, nie przydzieliliśmy Ci jeszcze żadnych dokumentów.');
-        
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
@@ -142,9 +140,14 @@
             }
         }
         
-        // If no documents, ensure the "no documents" message is displayed
+        // Update message based on whether documents exist
         if (!hasDocuments) {
-            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Brak dokumentów. Sprawdź ponownie później.</li>';
+            // Show "no documents" message from CMS
+            if (msgEl) msgEl.textContent = t('plDocumentsMessage', 'Brak dokumentów do wyświetlenia.');
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Sprawdź ponownie później.</li>';
+        } else {
+            // Show regular description when documents exist
+            if (msgEl) msgEl.textContent = 'Znajdziesz tutaj wszelkie dokumenty udostępnione Ci przez nas, takie jak umowy, broszury i prezentacje.';
         }
     });
     </script>

--- a/your-documents.html
+++ b/your-documents.html
@@ -99,8 +99,6 @@
         if (titleEl) titleEl.textContent = t('documentsTitle', 'Your Documents');
         
         const msgEl = document.getElementById('documents-message');
-        if (msgEl) msgEl.textContent = t('documentsMessage', 'Below you\'ll find any documents we\'ve shared with you, such as agreements, brochures and presentations. If nothing appears here you haven\'t been assigned any documents yet.');
-        
         const listElem = document.getElementById('documents-list');
         // Retrieve stored documents (an array of objects with name and data fields).
         const stored = localStorage.getItem('documents');
@@ -142,9 +140,14 @@
             }
         }
         
-        // If no documents, ensure the "no documents" message is displayed
+        // Update message based on whether documents exist
         if (!hasDocuments) {
-            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">No documents available yet. Check back later.</li>';
+            // Show "no documents" message from CMS
+            if (msgEl) msgEl.textContent = t('documentsMessage', 'No documents available yet.');
+            listElem.innerHTML = '<li class="bg-white p-4 rounded-lg shadow text-gray-500">Check back later for updates.</li>';
+        } else {
+            // Show regular description when documents exist
+            if (msgEl) msgEl.textContent = 'Below you\'ll find any documents we\'ve shared with you, such as agreements, brochures and presentations.';
         }
     });
     </script>


### PR DESCRIPTION
Fix calculator link redirection on mobile and conditionally display "No documents available yet" message.

The calculator link on mobile, when accessed from subpages, incorrectly tried to find the calculator section on the current subpage instead of redirecting to the home page. The "No documents available yet" message was always displayed because it was treated as a static description, not a conditional message. This PR ensures the calculator link always navigates to the home page's calculator section and correctly shows/hides the "No documents available yet" message based on document availability.

---
<a href="https://cursor.com/background-agent?bcId=bc-7be74d2f-934e-4380-a24a-16e60e2b5db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7be74d2f-934e-4380-a24a-16e60e2b5db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

