### PR TITLE
Fix cta text on frontend

### DIFF
--- a/how-it-works-pl.html
+++ b/how-it-works-pl.html
@@ -501,7 +501,7 @@
                 <button class="bg-black text-white px-12 py-4 rounded-full text-xl font-semibold hover:bg-gray-800 transition-colors">
                     Stwórz Swój Sklep Live-Selling
                 </button>
-                <p class="text-gray-500 text-sm mt-4">
+                <p id="how-cta-subtext" class="text-gray-500 text-sm mt-4">
                     Bezpłatna konsultacja • Brak opłat za konfigurację • Zacznij zarabiać w 1 tydzień
                 </p>
             </div>
@@ -594,13 +594,16 @@
         const howTitleElem = document.getElementById('how-title');
         const howSubtitleElem = document.getElementById('how-subtitle');
         const readyTitleElem = document.getElementById('ready-title');
+        const howCtaSubtextElem = document.getElementById('how-cta-subtext');
         // Prefer Polish values for How It Works page
         const storedHowTitle = localStorage.getItem('plHowTitle') || localStorage.getItem('howTitle');
         const storedHowSubtitle = localStorage.getItem('plHowSubtitle') || localStorage.getItem('howSubtitle');
         const storedReadyTitle = localStorage.getItem('plReadyTitle') || localStorage.getItem('readyTitle');
+        const storedHowCtaSubtext = localStorage.getItem('plHowCtaSubtext') || localStorage.getItem('howCtaSubtext');
         if (storedHowTitle) howTitleElem.textContent = storedHowTitle;
         if (storedHowSubtitle) howSubtitleElem.textContent = storedHowSubtitle;
         if (storedReadyTitle) readyTitleElem.textContent = storedReadyTitle;
+        if (storedHowCtaSubtext) howCtaSubtextElem.textContent = storedHowCtaSubtext;
     });
     </script>
 </body>

--- a/how-it-works.html
+++ b/how-it-works.html
@@ -501,7 +501,7 @@
                 <button id="cta-button" class="bg-black text-white px-12 py-4 rounded-full text-xl font-semibold hover:bg-gray-800 transition-colors">
                     Create Your Live-Selling Shop
                 </button>
-                <p class="text-gray-500 text-sm mt-4">
+                <p id="how-cta-subtext" class="text-gray-500 text-sm mt-4">
                     Free consultation • No setup fees • Start earning in 1 week
                 </p>
             </div>
@@ -595,12 +595,15 @@
         const howTitleElem = document.getElementById('how-title');
         const howSubtitleElem = document.getElementById('how-subtitle');
         const readyTitleElem = document.getElementById('ready-title');
+        const howCtaSubtextElem = document.getElementById('how-cta-subtext');
         const storedHowTitle = localStorage.getItem('howTitle');
         const storedHowSubtitle = localStorage.getItem('howSubtitle');
         const storedReadyTitle = localStorage.getItem('readyTitle');
+        const storedHowCtaSubtext = localStorage.getItem('howCtaSubtext');
         if (storedHowTitle) howTitleElem.textContent = storedHowTitle;
         if (storedHowSubtitle) howSubtitleElem.textContent = storedHowSubtitle;
         if (storedReadyTitle) readyTitleElem.textContent = storedReadyTitle;
+        if (storedHowCtaSubtext) howCtaSubtextElem.textContent = storedHowCtaSubtext;
     });
     </script>
 </body>

--- a/landing/how-it-works-pl.html
+++ b/landing/how-it-works-pl.html
@@ -501,7 +501,7 @@
                 <button class="bg-black text-white px-12 py-4 rounded-full text-xl font-semibold hover:bg-gray-800 transition-colors">
                     Stwórz Swój Sklep Live-Selling
                 </button>
-                <p class="text-gray-500 text-sm mt-4">
+                <p id="how-cta-subtext" class="text-gray-500 text-sm mt-4">
                     Bezpłatna konsultacja • Brak opłat za konfigurację • Zacznij zarabiać w 1 tydzień
                 </p>
             </div>
@@ -594,13 +594,16 @@
         const howTitleElem = document.getElementById('how-title');
         const howSubtitleElem = document.getElementById('how-subtitle');
         const readyTitleElem = document.getElementById('ready-title');
+        const howCtaSubtextElem = document.getElementById('how-cta-subtext');
         // Prefer Polish values for How It Works page
         const storedHowTitle = localStorage.getItem('plHowTitle') || localStorage.getItem('howTitle');
         const storedHowSubtitle = localStorage.getItem('plHowSubtitle') || localStorage.getItem('howSubtitle');
         const storedReadyTitle = localStorage.getItem('plReadyTitle') || localStorage.getItem('readyTitle');
+        const storedHowCtaSubtext = localStorage.getItem('plHowCtaSubtext') || localStorage.getItem('howCtaSubtext');
         if (storedHowTitle) howTitleElem.textContent = storedHowTitle;
         if (storedHowSubtitle) howSubtitleElem.textContent = storedHowSubtitle;
         if (storedReadyTitle) readyTitleElem.textContent = storedReadyTitle;
+        if (storedHowCtaSubtext) howCtaSubtextElem.textContent = storedHowCtaSubtext;
     });
     </script>
 </body>

--- a/landing/how-it-works.html
+++ b/landing/how-it-works.html
@@ -501,7 +501,7 @@
                 <button id="cta-button" class="bg-black text-white px-12 py-4 rounded-full text-xl font-semibold hover:bg-gray-800 transition-colors">
                     Create Your Live-Selling Shop
                 </button>
-                <p class="text-gray-500 text-sm mt-4">
+                <p id="how-cta-subtext" class="text-gray-500 text-sm mt-4">
                     Free consultation • No setup fees • Start earning in 1 week
                 </p>
             </div>
@@ -595,12 +595,15 @@
         const howTitleElem = document.getElementById('how-title');
         const howSubtitleElem = document.getElementById('how-subtitle');
         const readyTitleElem = document.getElementById('ready-title');
+        const howCtaSubtextElem = document.getElementById('how-cta-subtext');
         const storedHowTitle = localStorage.getItem('howTitle');
         const storedHowSubtitle = localStorage.getItem('howSubtitle');
         const storedReadyTitle = localStorage.getItem('readyTitle');
+        const storedHowCtaSubtext = localStorage.getItem('howCtaSubtext');
         if (storedHowTitle) howTitleElem.textContent = storedHowTitle;
         if (storedHowSubtitle) howSubtitleElem.textContent = storedHowSubtitle;
         if (storedReadyTitle) readyTitleElem.textContent = storedReadyTitle;
+        if (storedHowCtaSubtext) howCtaSubtextElem.textContent = storedHowCtaSubtext;
     });
     </script>
 </body>


### PR DESCRIPTION
Load "How It Works" CTA subtext from `localStorage` to display CMS changes on the frontend.

The CTA subtext was hardcoded in `how-it-works.html`, `how-it-works-pl.html`, `landing/how-it-works.html`, and `landing/how-it-works-pl.html`. This prevented changes made in the CMS (which correctly saved values to `localStorage`) from appearing on the frontend. The fix adds an ID to the relevant paragraph and JavaScript to load the `howCtaSubtext` (EN) or `plHowCtaSubtext` (PL) from `localStorage`.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3cecf33-011f-40f1-b7de-270b80b79fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3cecf33-011f-40f1-b7de-270b80b79fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

