### PR TITLE
Fix initial hero media flash

### DIFF
--- a/index-fashion-pl.html
+++ b/index-fashion-pl.html
@@ -299,7 +299,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
                             </div>
                         </div>
                     </div>

--- a/index-fashion-pl.html
+++ b/index-fashion-pl.html
@@ -199,6 +199,10 @@
             position: relative;
         }
         
+        .hero-media-item.fallback {
+            display: none;
+        }
+        
         .hero-media-item video {
             width: 100%;
             height: 100%;
@@ -299,7 +303,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active fallback">
                             </div>
                         </div>
                     </div>

--- a/index-fashion.html
+++ b/index-fashion.html
@@ -294,7 +294,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
                             </div>
                         </div>
                     </div>

--- a/index-fashion.html
+++ b/index-fashion.html
@@ -194,6 +194,10 @@
             position: relative;
         }
         
+        .hero-media-item.fallback {
+            display: none;
+        }
+        
         .hero-media-item video {
             width: 100%;
             height: 100%;
@@ -294,7 +298,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active fallback">
                             </div>
                         </div>
                     </div>

--- a/index-pl.html
+++ b/index-pl.html
@@ -335,7 +335,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
                             </div>
                         </div>
                     </div>

--- a/index-pl.html
+++ b/index-pl.html
@@ -233,6 +233,10 @@
             position: relative;
         }
         
+        .hero-media-item.fallback {
+            display: none;
+        }
+        
         .hero-media-item video {
             width: 100%;
             height: 100%;
@@ -335,7 +339,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active fallback">
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
                             </div>
                         </div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -194,6 +194,10 @@
             position: relative;
         }
         
+        .hero-media-item.fallback {
+            display: none;
+        }
+        
         .hero-media-item video {
             width: 100%;
             height: 100%;
@@ -295,7 +299,7 @@
                         <div class="bg-white p-2 rounded-xl shadow-xl">
                             <div id="hero-media-container" class="rounded-lg w-full relative overflow-hidden" style="min-height: 400px;">
                                 <!-- Default image - will be replaced by dynamic content -->
-                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active" style="display: none;">
+                                <img src="images/hero-market.jpg" alt="Live selling platform" class="rounded-lg w-full hero-media-item active fallback">
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Hide the default hero image in index files to prevent a flash of the old picture before video content loads.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9cefbd7-d00c-4000-9f8c-68969e3a3780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9cefbd7-d00c-4000-9f8c-68969e3a3780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

