### PR TITLE
Fix blog post display issue

### DIFF
--- a/blog-pl.html
+++ b/blog-pl.html
@@ -116,20 +116,20 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>
-                <p class="text-xl text-gray-600 max-w-3xl mx-auto">Read our latest insights, tips and stories to inspire your fashion journey.</p>
+                <p class="text-xl text-gray-600 max-w-3xl mx-auto">Przeczytaj nasze najnowsze porady, wskazówki i historie, które zainspirują Twoją modową podróż.</p>
             </div>
         </div>
     </section>
 
     <!-- Blog Posts Grid -->
-    <section class="pt-0 pb-16 bg-white">
+    <section class="pt-8 pb-16 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div id="blog-posts-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div>
-            <p id="no-posts-msg" class="text-gray-600 text-center mt-8 hidden">No blog posts available yet.</p>
+            <p id="no-posts-msg" class="text-gray-600 text-center mt-8 hidden">Nie ma jeszcze dostępnych postów na blogu.</p>
         </div>
     </section>
 

--- a/blog.html
+++ b/blog.html
@@ -115,7 +115,7 @@
     </div>
 
     <!-- Hero Section -->
-    <section class="pt-12 pb-8 bg-gradient-to-br from-gray-50 to-white text-center">
+    <section class="pt-24 pb-16 bg-gradient-to-br from-gray-50 to-white text-center">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="fade-in">
                 <h1 class="text-6xl font-display font-bold text-black mb-4">Blog</h1>
@@ -125,7 +125,7 @@
     </section>
 
     <!-- Blog Posts Grid -->
-    <section class="pt-0 pb-16 bg-white">
+    <section class="pt-8 pb-16 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div id="blog-posts-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"></div>
             <p id="no-posts-msg" class="text-gray-600 text-center mt-8 hidden">No blog posts available yet.</p>


### PR DESCRIPTION
Fix blog post display issues by adjusting hero section padding, blog grid spacing, and correcting Polish translations.

The hero section's title and subtitle were partially hidden behind the fixed navigation bar due to insufficient top padding. Additionally, the Polish blog page displayed English text for the subtitle and "no posts" message, and lacked proper spacing between the hero section and the blog posts grid.

---
<a href="https://cursor.com/background-agent?bcId=bc-dcf11f8f-b63b-45f9-b2bc-385f7f3397a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dcf11f8f-b63b-45f9-b2bc-385f7f3397a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

