### PR TITLE
Napraw ikonę punktu 3

### DIFF
--- a/index-fashion-pl.html
+++ b/index-fashion-pl.html
@@ -126,6 +126,9 @@
         .step-indicator {
             background: var(--primary-black);
             color: var(--primary-white);
+            min-width: 2.5rem;
+            min-height: 2.5rem;
+            flex-shrink: 0;
         }
         
         .step-indicator.active {

--- a/index-pl.html
+++ b/index-pl.html
@@ -126,6 +126,9 @@
         .step-indicator {
             background: var(--primary-black);
             color: var(--primary-white);
+            min-width: 2.5rem;
+            min-height: 2.5rem;
+            flex-shrink: 0;
         }
         
         .step-indicator.active {

--- a/landing/index-pl.html
+++ b/landing/index-pl.html
@@ -126,6 +126,9 @@
         .step-indicator {
             background: var(--primary-black);
             color: var(--primary-white);
+            min-width: 2.5rem;
+            min-height: 2.5rem;
+            flex-shrink: 0;
         }
         
         .step-indicator.active {


### PR DESCRIPTION
Add CSS to `.step-indicator` to prevent flex compression and ensure circular shape for step icons in Polish pages.

The `.step-indicator` elements were being flattened in flex layouts due to the absence of `min-width`, `min-height`, and `flex-shrink: 0` properties, which allowed the flex container to compress them. This fix ensures they maintain their intended circular appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-d565c61f-fc89-4400-9cbb-6e7021d315f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d565c61f-fc89-4400-9cbb-6e7021d315f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

