### PR TITLE
Fix strategic partners display on frontend

### DIFF
--- a/index-fashion-pl.html
+++ b/index-fashion-pl.html
@@ -217,6 +217,7 @@
     <!-- Cookie Consent -->
     <link rel="stylesheet" href="cookie-consent.css">
     <script src="cookie-consent.js" defer></script>
+    <script src="cms-sync.js"></script>
 </head>
 <body>
     <!-- Navigation -->

--- a/index-fashion.html
+++ b/index-fashion.html
@@ -209,6 +209,7 @@
     <!-- Cookie Consent -->
     <link rel="stylesheet" href="cookie-consent.css">
     <script src="cookie-consent.js" defer></script>
+    <script src="cms-sync.js"></script>
 </head>
 <body>
     <!-- Navigation -->


### PR DESCRIPTION
Add `cms-sync.js` script to fashion homepage files to display the Strategic Partners section.

The Strategic Partners section was not appearing on the frontend because the `cms-sync.js` script, responsible for loading CMS data, was missing from `index-fashion.html` and `index-fashion-pl.html`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b0e275c-1ed1-41f8-a56a-549e42001e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b0e275c-1ed1-41f8-a56a-549e42001e25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

