### PR TITLE
Fix strategic partners section visibility

### DIFF
--- a/STRATEGIC_PARTNERS_FIX.md
+++ b/STRATEGIC_PARTNERS_FIX.md
@@ -1,0 +1,49 @@
+# Strategic Partners Section - Fix Summary
+
+## Problem
+The Strategic Partners section was not visible on the frontend because the image path in the HTML code didn't match the actual filename.
+
+## Root Cause
+- **Expected filename**: `images/pako-lorente-logo.png`
+- **Actual filename**: `images/pakolorente.png`
+
+This mismatch caused the browser to fail loading the logo, and since it was the only partner displayed by default, the section appeared broken or invisible.
+
+## Files Fixed
+
+### 1. `/workspace/index-fashion-pl.html`
+- **Line 598**: Changed image path from `images/pako-lorente-logo.png` to `images/pakolorente.png`
+- **Status**: ✅ Fixed
+
+### 2. `/workspace/index-fashion.html`
+- **Line 590**: Changed image path from `images/pako-lorente-logo.png` to `images/pakolorente.png`
+- **Status**: ✅ Fixed
+
+### 3. `/workspace/admin.html`
+- **Line 4134**: Updated default partner logo path from `images/pako-lorente-logo.png` to `images/pakolorente.png`
+- **Status**: ✅ Fixed
+
+### 4. `/workspace/STRATEGIC_PARTNERS_GUIDE.md`
+- Updated all references to use correct filename `pakolorente.png`
+- Updated documentation examples
+- **Status**: ✅ Fixed
+
+## Verification
+- Logo file exists at: `/workspace/images/pakolorente.png` (19KB)
+- File format: PNG
+- No CSS hiding the section
+- Section properly positioned before "Ready to Start Your Fashion Empire?" section
+
+## Result
+The Strategic Partners section is now visible on both:
+- Polish version: `index-fashion-pl.html` (displaying "Strategiczni Partnerzy")
+- English version: `index-fashion.html` (displaying "Strategic Partners")
+
+## Next Steps
+1. Clear browser cache or hard refresh the page (Ctrl+F5 / Cmd+Shift+R)
+2. The section should now display the PAKO LORENTE logo correctly
+3. Additional partners can be managed through the Admin panel
+
+---
+**Fixed**: October 8, 2025  
+**Issue**: Logo filename mismatch preventing Strategic Partners section visibility

--- a/STRATEGIC_PARTNERS_GUIDE.md
+++ b/STRATEGIC_PARTNERS_GUIDE.md
@@ -17,7 +17,7 @@ A new "Strategic Partners" section has been added to both English and Polish ver
 ### 1. Upload the PAKO LORENTE Logo
 Upload your PAKO LORENTE logo to the `/images/` directory with the filename:
 ```
-pako-lorente-logo.png
+pakolorente.png
 ```
 
 The logo should be:
@@ -41,7 +41,7 @@ The logo should be:
 #### Add a New Partner
 1. In the "Add New Partner" section, fill in:
    - **Partner Name**: e.g., "PAKO LORENTE"
-   - **Logo Path**: e.g., "images/pako-lorente-logo.png"
+   - **Logo Path**: e.g., "images/pakolorente.png"
    - **Website URL**: (optional) e.g., "https://pakolorente.com"
 2. Click "Add Partner"
 
@@ -72,7 +72,7 @@ All partner data is stored in localStorage:
 ```javascript
 {
   "name": "PAKO LORENTE",
-  "logo": "images/pako-lorente-logo.png",
+  "logo": "images/pakolorente.png",
   "url": "https://pakolorente.com" // optional
 }
 ```

--- a/admin.html
+++ b/admin.html
@@ -4131,7 +4131,7 @@
             if (partners.length === 0) {
                 partners.push({
                     name: 'PAKO LORENTE',
-                    logo: 'images/pako-lorente-logo.png',
+                    logo: 'images/pakolorente.png',
                     url: ''
                 });
                 localStorage.setItem('strategicPartners', JSON.stringify(partners));

--- a/index-fashion-pl.html
+++ b/index-fashion-pl.html
@@ -595,7 +595,7 @@
             <div id="partners-grid" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 items-center justify-items-center">
                 <!-- Partners will be loaded dynamically from CMS -->
                 <div class="partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
-                    <img src="images/pako-lorente-logo.png" alt="PAKO LORENTE" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300">
+                    <img src="images/pakolorente.png" alt="PAKO LORENTE" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300">
                 </div>
             </div>
         </div>

--- a/index-fashion.html
+++ b/index-fashion.html
@@ -587,7 +587,7 @@
             <div id="partners-grid" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 items-center justify-items-center">
                 <!-- Partners will be loaded dynamically from CMS -->
                 <div class="partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
-                    <img src="images/pako-lorente-logo.png" alt="PAKO LORENTE" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300">
+                    <img src="images/pakolorente.png" alt="PAKO LORENTE" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fix Strategic Partners section visibility by correcting the logo image path.

The section was not visible on the frontend because the HTML and JavaScript referenced `images/pako-lorente-logo.png`, while the actual file was named `images/pakolorente.png`. This PR updates all relevant paths to the correct filename.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8bd0c2e-5235-44a2-a02c-ee926f3b334f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8bd0c2e-5235-44a2-a02c-ee926f3b334f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

