### PR TITLE
Fix strategic partners frontend display

### DIFF
--- a/index-pl.html
+++ b/index-pl.html
@@ -616,6 +616,24 @@
         </div>
     </section>
 
+    <!-- Strategic Partners Section -->
+    <section id="strategic-partners" class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-12 fade-in">
+                <h2 id="partners-title" class="text-4xl font-display font-bold text-black mb-4">Strategiczni Partnerzy</h2>
+                <p id="partners-subtitle" class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    Współpracujemy z liderami branży, aby zapewnić Ci najlepsze rozwiązania modowe
+                </p>
+            </div>
+            <div id="partners-grid" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 items-center justify-items-center">
+                <!-- Partners will be loaded dynamically from CMS -->
+                <div class="partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                    <img src="images/pakolorente.png" alt="PAKO LORENTE" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300">
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Start Your Brand Section -->
     <section id="start" class="py-20 bg-white">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -1293,6 +1311,34 @@
     });
 </script>
 
+<!-- Strategic Partners Loader Script -->
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const partnersTitle = document.getElementById('partners-title');
+    const partnersSubtitle = document.getElementById('partners-subtitle');
+    const partnersGrid = document.getElementById('partners-grid');
+    if (partnersTitle && partnersSubtitle && partnersGrid) {
+        const title = localStorage.getItem('partnersTitlePl') || 'Strategiczni Partnerzy';
+        const subtitle = localStorage.getItem('partnersSubtitlePl') || 'Współpracujemy z liderami branży, aby zapewnić Ci najlepsze rozwiązania modowe';
+        partnersTitle.textContent = title;
+        partnersSubtitle.textContent = subtitle;
+        const partners = JSON.parse(localStorage.getItem('strategicPartners') || '[]');
+        if (partners.length > 0) {
+            partnersGrid.innerHTML = '';
+            partners.forEach(partner => {
+                const partnerDiv = document.createElement('div');
+                partnerDiv.className = 'partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow';
+                if (partner.url) {
+                    partnerDiv.innerHTML = `<a href="${partner.url}" target="_blank" rel="noopener noreferrer" class="block"><img src="${partner.logo}" alt="${partner.name}" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300" onerror="this.style.display='none'; this.parentElement.innerHTML='<span class=\\'text-gray-400 text-sm\\'>${partner.name}</span>';"></a>`;
+                } else {
+                    partnerDiv.innerHTML = `<img src="${partner.logo}" alt="${partner.name}" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300" onerror="this.style.display='none'; this.parentElement.innerHTML='<span class=\\'text-gray-400 text-sm\\'>${partner.name}</span>';">`;
+                }
+                partnersGrid.appendChild(partnerDiv);
+            });
+        }
+    }
+});
+</script>
 <!-- Hero Media Carousel Script -->
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/index.html
+++ b/index.html
@@ -577,6 +577,24 @@
         </div>
     </section>
 
+    <!-- Strategic Partners Section -->
+    <section id="strategic-partners" class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-12 fade-in">
+                <h2 id="partners-title" class="text-4xl font-display font-bold text-black mb-4">Strategic Partners</h2>
+                <p id="partners-subtitle" class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    Working with industry leaders to bring you the best fashion solutions
+                </p>
+            </div>
+            <div id="partners-grid" class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-8 items-center justify-items-center">
+                <!-- Partners will be loaded dynamically from CMS -->
+                <div class="partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
+                    <img src="images/pakolorente.png" alt="PAKO LORENTE" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300">
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Start Your Brand Section -->
     <section id="start" class="py-20 bg-white">
         <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -1251,6 +1269,34 @@
     });
     </script>
 
+<!-- Strategic Partners Loader Script -->
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const partnersTitle = document.getElementById('partners-title');
+    const partnersSubtitle = document.getElementById('partners-subtitle');
+    const partnersGrid = document.getElementById('partners-grid');
+    if (partnersTitle && partnersSubtitle && partnersGrid) {
+        const title = localStorage.getItem('partnersTitle') || 'Strategic Partners';
+        const subtitle = localStorage.getItem('partnersSubtitle') || 'Working with industry leaders to bring you the best fashion solutions';
+        partnersTitle.textContent = title;
+        partnersSubtitle.textContent = subtitle;
+        const partners = JSON.parse(localStorage.getItem('strategicPartners') || '[]');
+        if (partners.length > 0) {
+            partnersGrid.innerHTML = '';
+            partners.forEach(partner => {
+                const partnerDiv = document.createElement('div');
+                partnerDiv.className = 'partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow';
+                if (partner.url) {
+                    partnerDiv.innerHTML = `<a href="${partner.url}" target="_blank" rel="noopener noreferrer" class="block"><img src="${partner.logo}" alt="${partner.name}" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300" onerror="this.style.display='none'; this.parentElement.innerHTML='<span class=\\'text-gray-400 text-sm\\'>${partner.name}</span>';"></a>`;
+                } else {
+                    partnerDiv.innerHTML = `<img src="${partner.logo}" alt="${partner.name}" class="w-full h-auto max-h-20 object-contain grayscale hover:grayscale-0 transition-all duration-300" onerror="this.style.display='none'; this.parentElement.innerHTML='<span class=\\'text-gray-400 text-sm\\'>${partner.name}</span>';">`;
+                }
+                partnersGrid.appendChild(partnerDiv);
+            });
+        }
+    }
+});
+</script>
 <!-- Hero Media Carousel Script -->
 <script>
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
Add Strategic Partners section to `index.html` and `index-pl.html` to ensure it renders on the main frontend pages.

The Strategic Partners section was previously only included in the fashion-specific landing pages (`index-fashion.html`, `index-fashion-pl.html`), preventing it from appearing on the primary English and Polish homepages. This PR adds the section and its corresponding loader scripts to the main `index.html` and `index-pl.html` files, allowing it to be managed via `admin.html` and displayed correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-c71a8252-48f0-40cf-b639-787880613bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c71a8252-48f0-40cf-b639-787880613bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

