### PR TITLE
Center partner logos in strategic partners

### DIFF
--- a/STRATEGIC_PARTNERS_CENTERING_FIX.md
+++ b/STRATEGIC_PARTNERS_CENTERING_FIX.md
@@ -1,0 +1,70 @@
+# Naprawa Centrowania Logo Partnerów - Strategic Partners
+
+## Data naprawy
+8 października 2025
+
+## Problem
+Logo partnerów w sekcji "Strategic Partners" nie były prawidłowo wycentrowane. Głównym problemem było użycie klasy CSS `inline-grid` zamiast `grid`, co uniemożliwiało prawidłowe centrowanie elementów.
+
+## Rozwiązanie
+Zmieniono klasę CSS z `inline-grid` na `grid` oraz dodano klasę `justify-center` dla zapewnienia pełnego centrowania logo partnerów.
+
+## Pliki zmodyfikowane
+
+### 1. index-fashion.html
+**Zmiany w HTML (linia 587):**
+- PRZED: `class="inline-grid grid-cols-1 gap-8 items-center justify-items-center mx-auto"`
+- PO: `class="grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto"`
+
+**Zmiany w JavaScript (linie 1277, 1279, 1281):**
+- 1 partner: `grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto`
+- 2 partnerów: `grid grid-cols-2 gap-8 items-center justify-items-center justify-center mx-auto`
+- 3+ partnerów: `grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 items-center justify-items-center justify-center`
+
+### 2. index-fashion-pl.html
+✅ Plik już miał prawidłowe ustawienia - nie wymagał zmian
+
+### 3. index.html
+**Zmiany w HTML (linia 589):**
+- PRZED: `class="inline-grid grid-cols-1 gap-8 items-center justify-items-center mx-auto"`
+- PO: `class="grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto"`
+
+**Zmiany w JavaScript (linie 1288, 1290, 1292):**
+- 1 partner: `grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto`
+- 2 partnerów: `grid grid-cols-2 gap-8 items-center justify-items-center justify-center mx-auto`
+- 3+ partnerów: `grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 items-center justify-items-center justify-center`
+
+### 4. index-pl.html
+✅ Plik już miał prawidłowe ustawienia - nie wymagał zmian
+
+## Wyjaśnienie klas CSS
+
+- `grid` - tworzy block-level grid container (w przeciwieństwie do `inline-grid`)
+- `justify-items-center` - centruje elementy wewnątrz komórek gridu
+- `justify-center` - centruje cały grid container
+- `mx-auto` - automatyczne marginesy poziome dla dodatkowego centrowania
+
+## Efekt
+Wszystkie logo partnerów (obecne i przyszłe) są teraz prawidłowo wycentrowane w sekcji Strategic Partners we wszystkich wersjach językowych strony:
+- index.html (EN - strona główna)
+- index-pl.html (PL - strona główna)
+- index-fashion.html (EN - strona fashion)
+- index-fashion-pl.html (PL - strona fashion)
+
+## Testowanie
+Aby przetestować zmiany:
+1. Otwórz którąkolwiek ze stron w przeglądarce
+2. Przewiń do sekcji "Strategic Partners" / "Strategiczni Partnerzy"
+3. Logo powinno być wycentrowane
+4. Dodaj więcej partnerów przez panel admin (admin.html)
+5. Wszystkie logo powinny pozostać wycentrowane niezależnie od ich liczby
+
+## Kompatybilność
+- ✅ Działa z 1 partnerem
+- ✅ Działa z 2 partnerami
+- ✅ Działa z 3+ partnerami
+- ✅ Responsywne na wszystkich urządzeniach
+- ✅ Zgodne z Tailwind CSS Play CDN
+
+---
+**Status:** ✅ NAPRAWIONE

--- a/index-fashion.html
+++ b/index-fashion.html
@@ -584,7 +584,7 @@
                     Working with industry leaders to bring you the best fashion solutions
                 </p>
             </div>
-            <div id="partners-grid" class="inline-grid grid-cols-1 gap-8 items-center justify-items-center mx-auto">
+            <div id="partners-grid" class="grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto">
                 <!-- Partners will be loaded dynamically from CMS -->
                 <div class="partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
                     <img src="images/pakolorente.png" alt="PAKO LORENTE" class="mx-auto h-auto max-h-[7.8rem] object-contain grayscale hover:grayscale-0 transition-all duration-300">
@@ -1274,9 +1274,9 @@ document.addEventListener('DOMContentLoaded', function() {
             partnersGrid.innerHTML = ''; // Clear default content
             // Use explicit Tailwind classes to support Play CDN (no dynamic classes)
             if (partners.length === 1) {
-                partnersGrid.className = 'inline-grid grid-cols-1 gap-8 items-center justify-items-center mx-auto';
+                partnersGrid.className = 'grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto';
             } else if (partners.length === 2) {
-                partnersGrid.className = 'inline-grid grid-cols-2 gap-8 items-center justify-items-center mx-auto';
+                partnersGrid.className = 'grid grid-cols-2 gap-8 items-center justify-items-center justify-center mx-auto';
             } else {
                 partnersGrid.className = 'grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 items-center justify-items-center justify-center';
             }

--- a/index.html
+++ b/index.html
@@ -586,7 +586,7 @@
                     Working with industry leaders to bring you the best fashion solutions
                 </p>
             </div>
-            <div id="partners-grid" class="inline-grid grid-cols-1 gap-8 items-center justify-items-center mx-auto">
+            <div id="partners-grid" class="grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto">
                 <!-- Partners will be loaded dynamically from CMS -->
                 <div class="partner-item bg-white p-6 rounded-lg shadow-sm hover:shadow-md transition-shadow">
                     <img src="images/pakolorente.png" alt="PAKO LORENTE" class="mx-auto h-auto max-h-[7.8rem] object-contain grayscale hover:grayscale-0 transition-all duration-300">
@@ -1285,9 +1285,9 @@ document.addEventListener('DOMContentLoaded', function() {
             partnersGrid.innerHTML = '';
             // Use explicit Tailwind classes to support Play CDN (no dynamic classes)
             if (partners.length === 1) {
-                partnersGrid.className = 'inline-grid grid-cols-1 gap-8 items-center justify-items-center mx-auto';
+                partnersGrid.className = 'grid grid-cols-1 gap-8 items-center justify-items-center justify-center mx-auto';
             } else if (partners.length === 2) {
-                partnersGrid.className = 'inline-grid grid-cols-2 gap-8 items-center justify-items-center mx-auto';
+                partnersGrid.className = 'grid grid-cols-2 gap-8 items-center justify-items-center justify-center mx-auto';
             } else {
                 partnersGrid.className = 'grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-8 items-center justify-items-center justify-center';
             }


### PR DESCRIPTION
Center partner logos in the Strategic Partners section by replacing `inline-grid` with `grid` and adding `justify-center` classes.

The previous use of `inline-grid` prevented the proper centering of the partner logo grid. Switching to `grid` and explicitly adding `justify-center` ensures that all logos, regardless of their count, are correctly centered within the section. This fix applies to both static HTML and dynamic class assignments in JavaScript.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e318c33-f750-4cc7-b6b4-bd7f2aa443b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e318c33-f750-4cc7-b6b4-bd7f2aa443b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

