### PR TITLE
Correct circle shape around point 3

### DIFF
--- a/index-pl.html
+++ b/index-pl.html
@@ -126,6 +126,8 @@
         .step-indicator {
             background: var(--primary-black);
             color: var(--primary-white);
+            width: 2.5rem;
+            height: 2.5rem;
             min-width: 2.5rem;
             min-height: 2.5rem;
             flex-shrink: 0;


### PR DESCRIPTION
Add explicit `width` and `height` to `.step-indicator` to ensure perfectly round step indicators.

The previous CSS used only `min-width` and `min-height`, which allowed the circle to become oval. Adding explicit `width` and `height` ensures a consistent circular shape for all step indicators.

---
<a href="https://cursor.com/background-agent?bcId=bc-38e06cfc-c5a4-477c-9aa2-fddb162f8719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38e06cfc-c5a4-477c-9aa2-fddb162f8719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

